### PR TITLE
Refine monitor timeline presentation

### DIFF
--- a/src/commands/monitor/mod.rs
+++ b/src/commands/monitor/mod.rs
@@ -59,18 +59,17 @@ use output::*;
 use panels::*;
 #[cfg(test)]
 use timeline::{
-    StageProgressState, TimelineStep, TimelineStepState, timeline_badge_cell, timeline_for_action,
-    timeline_separator, timeline_step_lines, timeline_step_spans,
+    StageProgressState, TimelineStep, TimelineStepState, timeline_for_action, timeline_separator,
+    timeline_step_lines, timeline_step_spans,
 };
 use timeline::{render_run_timeline, timeline_motion_frame};
 use view::*;
 
 const TUI_IDLE_TICK: Duration = Duration::from_millis(150);
-const TUI_ANIMATION_TICK: Duration = Duration::from_millis(100);
+const TUI_ANIMATION_TICK: Duration = Duration::from_nanos(16_666_667);
 const TUI_REDUCED_MOTION_TICK: Duration = Duration::from_millis(250);
 const CONTEXT_DETAILS_MIN_WIDTH: usize = 60;
 const OUTPUT_PREFIX_WIDTH: u16 = 12;
-const TIMELINE_BADGE_WIDTH: usize = 5;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum MotionMode {

--- a/src/commands/monitor/tests/interaction.rs
+++ b/src/commands/monitor/tests/interaction.rs
@@ -26,7 +26,7 @@ fn cancel_command_marks_run_and_sends_stop_signal() {
 }
 
 #[test]
-fn tui_tick_uses_a_calm_rate_while_command_is_running() {
+fn tui_tick_uses_sixty_hz_while_command_is_running() {
     let mut app = test_app();
     let (_event_tx, event_rx) = mpsc::channel();
     let (cancel_tx, _cancel_rx) = mpsc::channel();
@@ -40,7 +40,7 @@ fn tui_tick_uses_a_calm_rate_while_command_is_running() {
     });
 
     assert_eq!(tui_frame_tick(&app), TUI_ANIMATION_TICK);
-    assert_eq!(TUI_ANIMATION_TICK, Duration::from_millis(100));
+    assert_eq!(TUI_ANIMATION_TICK, Duration::from_nanos(16_666_667));
 }
 
 #[test]

--- a/src/commands/monitor/tests/timeline.rs
+++ b/src/commands/monitor/tests/timeline.rs
@@ -96,21 +96,39 @@ fn current_timeline_step_keeps_its_label_and_pulses_only_its_color() {
     let second = timeline_step_spans(&step, 1);
 
     assert_eq!(first[0].content, second[0].content);
-    assert_eq!(first[0].content.as_ref(), " RUN ");
-    assert_ne!(first[0].style.bg, second[0].style.bg);
+    assert_eq!(first[0].content.as_ref(), "Lock-in");
+    assert_eq!(first[2].content.as_ref(), "running");
+    assert_eq!(first[0].style.bg, None);
+    assert_ne!(first[0].style.fg, second[0].style.fg);
 }
 
 #[test]
-fn timeline_badges_are_centered_in_fixed_cells() {
-    assert_eq!(timeline_badge_cell("DONE"), "DONE ");
-    assert_eq!(timeline_badge_cell("RUN"), " RUN ");
-    assert_eq!(timeline_badge_cell("NEXT"), "NEXT ");
-    assert_eq!(timeline_badge_cell("FAIL"), "FAIL ");
-    assert_eq!(timeline_badge_cell("STOP"), "STOP ");
+fn timeline_states_use_flat_semantic_labels_without_background_boxes() {
+    for (state, expected) in [
+        (TimelineStepState::Done, "Read"),
+        (TimelineStepState::Current, "Read · running"),
+        (TimelineStepState::Pending, "Read"),
+        (TimelineStepState::Failed, "Read · failed"),
+        (TimelineStepState::Stopping, "Read · stopping"),
+    ] {
+        let spans = timeline_step_spans(
+            &TimelineStep {
+                label: "Read",
+                state,
+            },
+            0,
+        );
+        let rendered = spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect::<String>();
+        assert_eq!(rendered, expected);
+        assert!(spans.iter().all(|span| span.style.bg.is_none()));
+    }
 }
 
 #[test]
-fn pending_timeline_step_is_static_and_explicit() {
+fn pending_timeline_step_is_a_static_muted_stage_without_repeated_next_text() {
     let step = TimelineStep {
         label: "Read",
         state: TimelineStepState::Pending,
@@ -120,7 +138,9 @@ fn pending_timeline_step_is_static_and_explicit() {
     let second = timeline_step_spans(&step, 1);
 
     assert_eq!(first[0].content, second[0].content);
-    assert_eq!(first[0].content.as_ref(), "NEXT ");
+    assert_eq!(first[0].content.as_ref(), "Read");
+    assert_eq!(first.len(), 1);
+    assert_eq!(first[0].style.fg, Some(Color::DarkGray));
 }
 
 #[test]
@@ -170,7 +190,7 @@ fn compact_pending_timeline_step_is_static_and_clear() {
 }
 
 #[test]
-fn compact_current_timeline_step_uses_centered_cell() {
+fn compact_current_timeline_step_uses_plain_status_text() {
     let steps = vec![
         TimelineStep {
             label: "Read",

--- a/src/commands/monitor/timeline.rs
+++ b/src/commands/monitor/timeline.rs
@@ -6,9 +6,7 @@ use ratatui::{
 };
 use unicode_width::UnicodeWidthStr;
 
-use super::{LogEntry, MonitorAction, MonitorApp, TIMELINE_BADGE_WIDTH, strip_ansi_codes};
-
-const TIMELINE_COMPACT_BADGE_WIDTH: usize = 3;
+use super::{LogEntry, MonitorAction, MonitorApp, strip_ansi_codes};
 
 pub(super) fn render_run_timeline(frame: &mut Frame<'_>, app: &MonitorApp, area: Rect) {
     if area.height == 0 || area.width == 0 {
@@ -58,13 +56,12 @@ pub(super) fn render_run_timeline(frame: &mut Frame<'_>, app: &MonitorApp, area:
         ]
     } else {
         let mut compact = vec![Span::styled(
-            " TIMELINE ",
+            "Timeline",
             Style::default()
-                .fg(Color::Black)
-                .bg(Color::Cyan)
+                .fg(Color::Cyan)
                 .add_modifier(Modifier::BOLD),
         )];
-        compact.push(Span::raw(" "));
+        compact.push(Span::raw("  "));
         compact.extend(timeline_compact_step_spans(&timeline.steps, motion_frame));
         vec![Line::from(compact)]
     };
@@ -74,13 +71,12 @@ pub(super) fn render_run_timeline(frame: &mut Frame<'_>, app: &MonitorApp, area:
 fn timeline_header_line(done: usize, total: usize) -> Line<'static> {
     Line::from(vec![
         Span::styled(
-            " TIMELINE ",
+            "Timeline",
             Style::default()
-                .fg(Color::Black)
-                .bg(Color::Cyan)
+                .fg(Color::Cyan)
                 .add_modifier(Modifier::BOLD),
         ),
-        Span::raw(" "),
+        Span::raw("  "),
         Span::styled(
             format!("{done}/{total} complete"),
             Style::default().fg(Color::Gray),
@@ -179,16 +175,6 @@ pub(super) fn timeline_motion_frame(app: &MonitorApp) -> usize {
         .unwrap_or(0)
 }
 
-fn timeline_state_label(state: TimelineStepState) -> &'static str {
-    match state {
-        TimelineStepState::Done => "DONE",
-        TimelineStepState::Current => "RUN",
-        TimelineStepState::Pending => "NEXT",
-        TimelineStepState::Failed => "FAIL",
-        TimelineStepState::Stopping => "STOP",
-    }
-}
-
 fn timeline_compact_state_label(state: TimelineStepState) -> &'static str {
     match state {
         TimelineStepState::Done => "OK",
@@ -218,7 +204,7 @@ fn timeline_connector_span(next_step: &TimelineStep, _frame: usize) -> Span<'sta
     } else {
         Style::default().fg(Color::DarkGray)
     };
-    Span::styled(" ─ ", style)
+    Span::styled("  ›  ", style)
 }
 
 fn timeline_compact_connector_span(next_step: &TimelineStep, _frame: usize) -> Span<'static> {
@@ -236,20 +222,63 @@ fn timeline_compact_connector_span(next_step: &TimelineStep, _frame: usize) -> S
 }
 
 pub(super) fn timeline_step_spans(step: &TimelineStep, frame: usize) -> Vec<Span<'static>> {
-    let (fg, bg, modifier) = match step.state {
-        TimelineStepState::Done => (Color::Black, Color::Green, Modifier::BOLD),
-        TimelineStepState::Current => (Color::Black, timeline_pulse_color(frame), Modifier::BOLD),
-        TimelineStepState::Pending => (Color::DarkGray, Color::Reset, Modifier::empty()),
-        TimelineStepState::Failed => (Color::Black, Color::LightRed, Modifier::BOLD),
-        TimelineStepState::Stopping => (Color::Black, Color::Yellow, Modifier::BOLD),
-    };
-    let badge_style = if matches!(step.state, TimelineStepState::Pending) {
-        Style::default().fg(fg)
-    } else {
-        Style::default().fg(fg).bg(bg).add_modifier(modifier)
-    };
-    let label_style = match step.state {
-        TimelineStepState::Done => Style::default().fg(Color::Green),
+    match step.state {
+        TimelineStepState::Done => vec![Span::styled(
+            step.label.to_string(),
+            Style::default().fg(Color::Green),
+        )],
+        TimelineStepState::Current => {
+            let style = Style::default()
+                .fg(timeline_pulse_color(frame))
+                .add_modifier(Modifier::BOLD);
+            vec![
+                Span::styled(step.label.to_string(), style),
+                Span::styled(" · ", Style::default().fg(Color::DarkGray)),
+                Span::styled("running", style),
+            ]
+        }
+        TimelineStepState::Pending => vec![Span::styled(
+            step.label.to_string(),
+            Style::default().fg(Color::DarkGray),
+        )],
+        TimelineStepState::Failed => vec![
+            Span::styled(
+                step.label.to_string(),
+                Style::default()
+                    .fg(Color::LightRed)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" · ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                "failed",
+                Style::default()
+                    .fg(Color::LightRed)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ],
+        TimelineStepState::Stopping => vec![
+            Span::styled(
+                step.label.to_string(),
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" · ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                "stopping",
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ],
+    }
+}
+
+fn timeline_compact_step_span(step: &TimelineStep, frame: usize) -> Span<'static> {
+    let style = match step.state {
+        TimelineStepState::Done => Style::default()
+            .fg(Color::Green)
+            .add_modifier(Modifier::BOLD),
         TimelineStepState::Current => Style::default()
             .fg(timeline_pulse_color(frame))
             .add_modifier(Modifier::BOLD),
@@ -261,56 +290,7 @@ pub(super) fn timeline_step_spans(step: &TimelineStep, frame: usize) -> Vec<Span
             .fg(Color::Yellow)
             .add_modifier(Modifier::BOLD),
     };
-
-    vec![
-        Span::styled(
-            timeline_badge_cell(timeline_state_label(step.state)),
-            badge_style,
-        ),
-        Span::raw(" "),
-        Span::styled(step.label.to_string(), label_style),
-    ]
-}
-
-pub(super) fn timeline_badge_cell(icon: &str) -> String {
-    let len = icon.chars().count();
-    if len >= TIMELINE_BADGE_WIDTH {
-        return icon.to_string();
-    }
-    let padding = TIMELINE_BADGE_WIDTH - len;
-    let left = padding / 2;
-    let right = padding - left;
-    format!("{}{}{}", " ".repeat(left), icon, " ".repeat(right))
-}
-
-fn timeline_compact_step_span(step: &TimelineStep, frame: usize) -> Span<'static> {
-    let (fg, bg, modifier) = match step.state {
-        TimelineStepState::Done => (Color::Black, Color::Green, Modifier::BOLD),
-        TimelineStepState::Current => (Color::Black, timeline_pulse_color(frame), Modifier::BOLD),
-        TimelineStepState::Pending => (Color::DarkGray, Color::Reset, Modifier::empty()),
-        TimelineStepState::Failed => (Color::Black, Color::LightRed, Modifier::BOLD),
-        TimelineStepState::Stopping => (Color::Black, Color::Yellow, Modifier::BOLD),
-    };
-    let style = if matches!(step.state, TimelineStepState::Pending) {
-        Style::default().fg(fg)
-    } else {
-        Style::default().fg(fg).bg(bg).add_modifier(modifier)
-    };
-    Span::styled(
-        timeline_compact_badge_cell(timeline_compact_state_label(step.state)),
-        style,
-    )
-}
-
-fn timeline_compact_badge_cell(icon: &str) -> String {
-    let len = icon.chars().count();
-    if len >= TIMELINE_COMPACT_BADGE_WIDTH {
-        return icon.to_string();
-    }
-    let padding = TIMELINE_COMPACT_BADGE_WIDTH - len;
-    let left = padding / 2;
-    let right = padding - left;
-    format!("{}{}{}", " ".repeat(left), icon, " ".repeat(right))
+    Span::styled(timeline_compact_state_label(step.state), style)
 }
 
 fn line_width(line: &Line<'_>) -> usize {


### PR DESCRIPTION
## Summary

- replace fixed-width timeline status boxes with a flat stage-first layout
- remove repeated `Next` labels while keeping running, failed, and stopping states explicit
- refresh full-motion TUI animation at 60 Hz

## Validation

- `cargo test --locked -p pmoke --all-targets --no-default-features`
- `cargo clippy --locked -p pmoke --all-targets --no-default-features -- -D warnings`
- `cargo check --locked --workspace --all-targets --all-features`
- `cargo fmt --all -- --check`
- `git diff --check`