### PR TITLE
refactor: share connection URI parsing

### DIFF
--- a/src/commands/instruments.rs
+++ b/src/commands/instruments.rs
@@ -1,4 +1,5 @@
 use crate::cli::{InstrumentsCommand, JsonOutput};
+use crate::connection::{ConnectionDefaults, ConnectionUri};
 use crate::ui;
 use anyhow::{Context, Result, anyhow, bail};
 use instruments::registry::{InstrumentSpec, KNOWN_INSTRUMENTS};
@@ -8,9 +9,6 @@ use std::collections::BTreeSet;
 use std::io::{BufRead, BufReader, Write};
 use std::net::{TcpStream, ToSocketAddrs};
 use std::time::Duration;
-
-const DEFAULT_PROLOGIX_PORT: u16 = 1234;
-const DEFAULT_PROLOGIX_BAUD_RATE: u32 = 115_200;
 
 #[derive(Debug, Serialize, PartialEq, Eq)]
 struct InstrumentListItem {
@@ -455,79 +453,56 @@ pub(crate) fn parse_query_connection(
     if default_timeout_ms == 0 {
         bail!("timeout_ms must be positive");
     }
-    if let Some(endpoint) = value.strip_prefix("tcp://") {
-        let (host, port) = parse_host_port(endpoint, "TCP")?;
-        return Ok(QueryConnection::Tcpip { host, port });
-    }
-    if value.starts_with("visa:") {
-        bail!(
+    let parsed = ConnectionUri::parse(
+        value,
+        ConnectionDefaults {
+            prologix_read_timeout_ms: default_timeout_ms,
+        },
+    )
+    .map_err(anyhow::Error::msg)?;
+    Ok(match parsed {
+        ConnectionUri::Tcp { host, port } => QueryConnection::Tcpip { host, port },
+        ConnectionUri::Visa { .. } => bail!(
             "visa connections are not supported by generic instruments query yet; use a TCP/IP, GPIB, or Prologix SCPI connection"
-        );
-    }
-    if let Some(endpoint) = value.strip_prefix("gpib://") {
-        let (board, address) = endpoint
-            .split_once('/')
-            .ok_or_else(|| anyhow!("GPIB connection must be gpib://board/address"))?;
-        let board = parse_u8(board, "GPIB board")?;
-        let address = parse_gpib_address(address, "GPIB address")?;
-        return Ok(QueryConnection::Scpi(ScpiConnection::Gpib {
+        ),
+        ConnectionUri::Gpib { board, address } => QueryConnection::Scpi(ScpiConnection::Gpib {
             board: i32::from(board),
             address: i32::from(address),
             timeout_secs: timeout_ms_to_secs(default_timeout_ms),
             use_crlf: false,
-        }));
-    }
-    if let Some(endpoint) = value.strip_prefix("prologix-tcp://") {
-        let (endpoint, query) = split_query(endpoint);
-        let params = parse_query_params(query)?;
-        validate_query_param_keys(&params, &["addr", "address", "read_timeout_ms"])?;
-        let address = parse_required_address_param(&params)?;
-        let read_timeout_ms = parse_timeout_param(&params, default_timeout_ms)?;
-        let (host, port) =
-            parse_optional_host_port(endpoint, DEFAULT_PROLOGIX_PORT, "Prologix TCP")?;
-        return Ok(QueryConnection::Scpi(ScpiConnection::PrologixTcp {
+        }),
+        ConnectionUri::PrologixTcp {
             host,
             port,
             address,
             read_timeout_ms,
-        }));
-    }
-    if let Some(endpoint) = value.strip_prefix("prologix-serial://") {
-        let (path, query) = split_query(endpoint);
-        let params = parse_query_params(query)?;
-        validate_query_param_keys(
-            &params,
-            &["addr", "address", "baud_rate", "read_timeout_ms"],
-        )?;
-        let address = parse_required_address_param(&params)?;
-        let read_timeout_ms = parse_timeout_param(&params, default_timeout_ms)?;
-        let baud_rate = parse_optional_u32_param(&params, "baud_rate", DEFAULT_PROLOGIX_BAUD_RATE)?;
-        if baud_rate == 0 {
-            bail!("Prologix serial baud_rate must be positive");
-        }
-        let path = path.trim();
-        if path.is_empty() {
-            bail!("Prologix serial path must not be empty");
-        }
-        return Ok(QueryConnection::Scpi(ScpiConnection::PrologixSerial {
-            path: path.to_string(),
+        } => QueryConnection::Scpi(ScpiConnection::PrologixTcp {
+            host,
+            port,
+            address,
+            read_timeout_ms,
+        }),
+        ConnectionUri::PrologixSerial {
+            path,
             address,
             baud_rate,
             read_timeout_ms,
-        }));
-    }
-
-    bail!(
-        "unsupported connection URI '{value}'; use tcp://host:port, gpib://board/address, prologix-tcp://host[:port]?addr=address, or prologix-serial:///path?addr=address"
-    )
+        } => QueryConnection::Scpi(ScpiConnection::PrologixSerial {
+            path,
+            address,
+            baud_rate,
+            read_timeout_ms,
+        }),
+    })
 }
 
 pub(crate) fn display_query_connection(connection: &QueryConnection) -> String {
     match connection {
-        QueryConnection::Tcpip { host, port } if host.contains(':') => {
-            format!("tcp://[{host}]:{port}")
+        QueryConnection::Tcpip { host, port } => ConnectionUri::Tcp {
+            host: host.clone(),
+            port: *port,
         }
-        QueryConnection::Tcpip { host, port } => format!("tcp://{host}:{port}"),
+        .to_string(),
         QueryConnection::Scpi(ScpiConnection::Gpib { board, address, .. }) => {
             format!("gpib://{board}/{address}")
         }
@@ -536,29 +511,25 @@ pub(crate) fn display_query_connection(connection: &QueryConnection) -> String {
             port,
             address,
             read_timeout_ms,
-        }) if host.contains(':') => {
-            format!(
-                "prologix-tcp://[{host}]:{port}?addr={address}&read_timeout_ms={read_timeout_ms}"
-            )
+        }) => ConnectionUri::PrologixTcp {
+            host: host.clone(),
+            port: *port,
+            address: *address,
+            read_timeout_ms: *read_timeout_ms,
         }
-        QueryConnection::Scpi(ScpiConnection::PrologixTcp {
-            host,
-            port,
-            address,
-            read_timeout_ms,
-        }) => {
-            format!("prologix-tcp://{host}:{port}?addr={address}&read_timeout_ms={read_timeout_ms}")
-        }
+        .to_string(),
         QueryConnection::Scpi(ScpiConnection::PrologixSerial {
             path,
             address,
             baud_rate,
             read_timeout_ms,
-        }) => {
-            format!(
-                "prologix-serial://{path}?addr={address}&baud_rate={baud_rate}&read_timeout_ms={read_timeout_ms}"
-            )
+        }) => ConnectionUri::PrologixSerial {
+            path: path.clone(),
+            address: *address,
+            baud_rate: *baud_rate,
+            read_timeout_ms: *read_timeout_ms,
         }
+        .to_string(),
     }
 }
 
@@ -578,136 +549,6 @@ pub(crate) fn configured_query_timeout_ms(
             read_timeout_ms, ..
         }) => u64::from(*read_timeout_ms),
     }
-}
-
-fn parse_host_port(endpoint: &str, label: &str) -> Result<(String, u16)> {
-    parse_optional_host_port(endpoint, 0, label)
-}
-
-fn parse_optional_host_port(
-    endpoint: &str,
-    default_port: u16,
-    label: &str,
-) -> Result<(String, u16)> {
-    let (host, port) = if let Some(rest) = endpoint.strip_prefix('[') {
-        if let Some((host, port)) = rest.split_once("]:") {
-            (
-                host,
-                port.parse::<u16>()
-                    .with_context(|| format!("invalid {label} port: {port}"))?,
-            )
-        } else if let Some(host) = rest.strip_suffix(']') {
-            (host, default_port)
-        } else {
-            bail!("{label} IPv6 endpoint must be [address]:port or [address]");
-        }
-    } else if let Some((host, port)) = endpoint.rsplit_once(':') {
-        if host.contains(':') {
-            bail!("{label} IPv6 endpoint must use [address]:port or [address]");
-        }
-        (
-            host,
-            port.parse::<u16>()
-                .with_context(|| format!("invalid {label} port: {port}"))?,
-        )
-    } else {
-        (endpoint, default_port)
-    };
-    let host = host.trim();
-    if host.is_empty() {
-        bail!("{label} host must not be empty");
-    }
-    if port == 0 {
-        bail!("{label} endpoint must include a port");
-    }
-    Ok((host.to_string(), port))
-}
-
-fn split_query(value: &str) -> (&str, Option<&str>) {
-    match value.split_once('?') {
-        Some((base, query)) => (base, Some(query)),
-        None => (value, None),
-    }
-}
-
-fn parse_query_params(query: Option<&str>) -> Result<Vec<(&str, &str)>> {
-    let Some(query) = query else {
-        return Ok(Vec::new());
-    };
-    query
-        .split('&')
-        .filter(|part| !part.is_empty())
-        .map(|part| {
-            part.split_once('=')
-                .ok_or_else(|| anyhow!("query parameter '{part}' must be key=value"))
-        })
-        .collect()
-}
-
-fn validate_query_param_keys(params: &[(&str, &str)], allowed: &[&str]) -> Result<()> {
-    for (key, _) in params {
-        if !allowed.contains(key) {
-            bail!("unsupported query parameter: {key}");
-        }
-    }
-    Ok(())
-}
-
-fn parse_required_address_param(params: &[(&str, &str)]) -> Result<u8> {
-    let address = find_unique_query_param(params, &["addr", "address"], "Prologix address")?
-        .ok_or_else(|| anyhow!("Prologix connection must include addr=0..30"))?;
-    parse_gpib_address(address, "Prologix address")
-}
-
-fn parse_timeout_param(params: &[(&str, &str)], default_timeout_ms: u64) -> Result<u16> {
-    let timeout = match find_unique_query_param(params, &["read_timeout_ms"], "read_timeout_ms")? {
-        Some(value) => value
-            .parse::<u64>()
-            .with_context(|| format!("invalid read_timeout_ms: {value}"))?,
-        None => default_timeout_ms,
-    };
-    if !(1..=3000).contains(&timeout) {
-        bail!("Prologix read_timeout_ms must be in 1..=3000 (got {timeout})");
-    }
-    Ok(timeout as u16)
-}
-
-fn parse_optional_u32_param(params: &[(&str, &str)], key: &str, default: u32) -> Result<u32> {
-    let Some(value) = find_unique_query_param(params, &[key], key)? else {
-        return Ok(default);
-    };
-    value
-        .parse::<u32>()
-        .with_context(|| format!("invalid {key}: {value}"))
-}
-
-fn find_unique_query_param<'a>(
-    params: &[(&str, &'a str)],
-    keys: &[&str],
-    label: &str,
-) -> Result<Option<&'a str>> {
-    let mut values = params
-        .iter()
-        .filter_map(|(key, value)| keys.contains(key).then_some(*value));
-    let value = values.next();
-    if values.next().is_some() {
-        bail!("{label} must be specified only once");
-    }
-    Ok(value)
-}
-
-fn parse_gpib_address(value: &str, label: &str) -> Result<u8> {
-    let address = parse_u8(value, label)?;
-    if address > 30 {
-        bail!("{label} must be in 0..=30 (got {address})");
-    }
-    Ok(address)
-}
-
-fn parse_u8(value: &str, label: &str) -> Result<u8> {
-    value
-        .parse::<u8>()
-        .with_context(|| format!("invalid {label}: {value}"))
 }
 
 fn timeout_ms_to_secs(timeout_ms: u64) -> u64 {

--- a/src/config/load.rs
+++ b/src/config/load.rs
@@ -1,8 +1,5 @@
 use super::*;
-
-const PROLOGIX_DEFAULT_PORT: u16 = 1234;
-const PROLOGIX_DEFAULT_BAUD_RATE: u32 = 115_200;
-const PROLOGIX_DEFAULT_READ_TIMEOUT_MS: u16 = 3000;
+use crate::connection::{ConnectionDefaults, ConnectionUri};
 
 pub fn load_from_path(path: impl AsRef<Path>) -> ConfigLoad {
     let path = path.as_ref();
@@ -855,274 +852,32 @@ fn parse_connection_v4(
             Some("use tcp://host:port, visa:RESOURCE, gpib://board/address, prologix-tcp://host[:port]?addr=address, or prologix-serial:///path?addr=address".to_string()),
         )
     };
-    if let Some(endpoint) = value.strip_prefix("tcp://") {
-        let (host, port) = parse_tcp_endpoint_v4(endpoint)
-            .map_err(|message| invalid(format!("invalid TCP connection '{value}': {message}")))?;
-        return Ok(Connection::Tcpip { ip: host, port });
-    }
-    if let Some(resource) = value.strip_prefix("visa:") {
-        let resource = resource.trim();
-        if resource.is_empty() {
-            return Err(invalid("VISA resource must not be empty".to_string()));
-        }
-        return Ok(Connection::Usbtmc {
-            resource: resource.to_string(),
-        });
-    }
-    if let Some(endpoint) = value.strip_prefix("gpib://") {
-        let (board, address) = endpoint
-            .split_once('/')
-            .ok_or_else(|| invalid("GPIB connection must be gpib://board/address".to_string()))?;
-        let board = board
-            .parse::<u8>()
-            .map_err(|_| invalid(format!("invalid GPIB board: {board}")))?;
-        let address = address
-            .parse::<u8>()
-            .map_err(|_| invalid(format!("invalid GPIB address: {address}")))?;
-        if address > 30 {
-            return Err(invalid(format!(
-                "GPIB address must be in 0..=30 (got {address})"
-            )));
-        }
-        return Ok(Connection::Gpib { board, address });
-    }
-    if let Some(endpoint) = value.strip_prefix("prologix-tcp://") {
-        let (endpoint, query) = split_query_v4(endpoint);
-        let params = parse_query_params_v4(query).map_err(|message| {
-            invalid(format!(
-                "invalid Prologix TCP connection '{value}': {message}"
-            ))
-        })?;
-        validate_query_param_keys_v4(&params, &["addr", "address", "read_timeout_ms"], &invalid)?;
-        let address = parse_required_address_param_v4(&params, &invalid)?;
-        let read_timeout_ms = parse_optional_u16_param_v4(
-            &params,
-            "read_timeout_ms",
-            PROLOGIX_DEFAULT_READ_TIMEOUT_MS,
-            &invalid,
-        )?;
-        validate_prologix_read_timeout_ms_v4(read_timeout_ms, &invalid)?;
-        let (host, port) = parse_prologix_tcp_endpoint_v4(endpoint).map_err(|message| {
-            invalid(format!(
-                "invalid Prologix TCP connection '{value}': {message}"
-            ))
-        })?;
-        return Ok(Connection::PrologixTcp {
+    let parsed = ConnectionUri::parse(value, ConnectionDefaults::default()).map_err(invalid)?;
+    Ok(match parsed {
+        ConnectionUri::Tcp { host, port } => Connection::Tcpip { ip: host, port },
+        ConnectionUri::Visa { resource } => Connection::Usbtmc { resource },
+        ConnectionUri::Gpib { board, address } => Connection::Gpib { board, address },
+        ConnectionUri::PrologixTcp {
             host,
             port,
             address,
             read_timeout_ms,
-        });
-    }
-    if let Some(endpoint) = value.strip_prefix("prologix-serial://") {
-        let (path, query) = split_query_v4(endpoint);
-        let params = parse_query_params_v4(query).map_err(|message| {
-            invalid(format!(
-                "invalid Prologix serial connection '{value}': {message}"
-            ))
-        })?;
-        validate_query_param_keys_v4(
-            &params,
-            &["addr", "address", "baud_rate", "read_timeout_ms"],
-            &invalid,
-        )?;
-        let address = parse_required_address_param_v4(&params, &invalid)?;
-        let read_timeout_ms = parse_optional_u16_param_v4(
-            &params,
-            "read_timeout_ms",
-            PROLOGIX_DEFAULT_READ_TIMEOUT_MS,
-            &invalid,
-        )?;
-        validate_prologix_read_timeout_ms_v4(read_timeout_ms, &invalid)?;
-        let baud_rate = parse_optional_u32_param_v4(
-            &params,
-            "baud_rate",
-            PROLOGIX_DEFAULT_BAUD_RATE,
-            &invalid,
-        )?;
-        if baud_rate == 0 {
-            return Err(invalid(
-                "Prologix serial baud_rate must be positive".to_string(),
-            ));
-        }
-        let path = path.trim();
-        if path.is_empty() {
-            return Err(invalid(
-                "Prologix serial path must not be empty".to_string(),
-            ));
-        }
-        return Ok(Connection::PrologixSerial {
-            path: path.to_string(),
+        } => Connection::PrologixTcp {
+            host,
+            port,
+            address,
+            read_timeout_ms,
+        },
+        ConnectionUri::PrologixSerial {
+            path,
             address,
             baud_rate,
             read_timeout_ms,
-        });
-    }
-    Err(invalid(format!("unsupported connection string: {value}")))
-}
-
-fn parse_tcp_endpoint_v4(endpoint: &str) -> std::result::Result<(String, u16), String> {
-    let (host, port) = if let Some(rest) = endpoint.strip_prefix('[') {
-        let (host, port) = rest
-            .split_once("]:")
-            .ok_or_else(|| "IPv6 endpoint must be [address]:port".to_string())?;
-        (host, port)
-    } else {
-        endpoint
-            .rsplit_once(':')
-            .ok_or_else(|| "endpoint must include a port".to_string())?
-    };
-    let host = host.trim();
-    if host.is_empty() {
-        return Err("host must not be empty".to_string());
-    }
-    let port = port
-        .parse::<u16>()
-        .map_err(|_| format!("invalid port: {port}"))?;
-    if port == 0 {
-        return Err("port must be in 1..=65535".to_string());
-    }
-    Ok((host.to_string(), port))
-}
-
-fn split_query_v4(value: &str) -> (&str, Option<&str>) {
-    match value.split_once('?') {
-        Some((base, query)) => (base, Some(query)),
-        None => (value, None),
-    }
-}
-
-fn parse_query_params_v4(query: Option<&str>) -> std::result::Result<Vec<(&str, &str)>, String> {
-    let Some(query) = query else {
-        return Ok(Vec::new());
-    };
-    query
-        .split('&')
-        .filter(|part| !part.is_empty())
-        .map(|part| {
-            part.split_once('=')
-                .ok_or_else(|| format!("query parameter '{part}' must be key=value"))
-        })
-        .collect()
-}
-
-fn validate_query_param_keys_v4(
-    params: &[(&str, &str)],
-    allowed: &[&str],
-    invalid: &impl Fn(String) -> ConfigDiagnostic,
-) -> std::result::Result<(), ConfigDiagnostic> {
-    for (key, _) in params {
-        if !allowed.contains(key) {
-            return Err(invalid(format!("unsupported query parameter: {key}")));
-        }
-    }
-    Ok(())
-}
-
-fn parse_required_address_param_v4(
-    params: &[(&str, &str)],
-    invalid: &impl Fn(String) -> ConfigDiagnostic,
-) -> std::result::Result<u8, ConfigDiagnostic> {
-    let address = params
-        .iter()
-        .find_map(|(key, value)| (*key == "addr" || *key == "address").then_some(*value))
-        .ok_or_else(|| invalid("Prologix connection must include addr=0..30".to_string()))?;
-    let address = address
-        .parse::<u8>()
-        .map_err(|_| invalid(format!("invalid Prologix address: {address}")))?;
-    if address > 30 {
-        return Err(invalid(format!(
-            "Prologix address must be in 0..=30 (got {address})"
-        )));
-    }
-    Ok(address)
-}
-
-fn parse_optional_u16_param_v4(
-    params: &[(&str, &str)],
-    key: &str,
-    default: u16,
-    invalid: &impl Fn(String) -> ConfigDiagnostic,
-) -> std::result::Result<u16, ConfigDiagnostic> {
-    let Some(value) = params
-        .iter()
-        .find_map(|(candidate, value)| (*candidate == key).then_some(*value))
-    else {
-        return Ok(default);
-    };
-    value
-        .parse::<u16>()
-        .map_err(|_| invalid(format!("invalid {key}: {value}")))
-}
-
-fn parse_optional_u32_param_v4(
-    params: &[(&str, &str)],
-    key: &str,
-    default: u32,
-    invalid: &impl Fn(String) -> ConfigDiagnostic,
-) -> std::result::Result<u32, ConfigDiagnostic> {
-    let Some(value) = params
-        .iter()
-        .find_map(|(candidate, value)| (*candidate == key).then_some(*value))
-    else {
-        return Ok(default);
-    };
-    value
-        .parse::<u32>()
-        .map_err(|_| invalid(format!("invalid {key}: {value}")))
-}
-
-fn validate_prologix_read_timeout_ms_v4(
-    read_timeout_ms: u16,
-    invalid: &impl Fn(String) -> ConfigDiagnostic,
-) -> std::result::Result<(), ConfigDiagnostic> {
-    if (1..=3000).contains(&read_timeout_ms) {
-        Ok(())
-    } else {
-        Err(invalid(format!(
-            "Prologix read_timeout_ms must be in 1..=3000 (got {read_timeout_ms})"
-        )))
-    }
-}
-
-fn parse_prologix_tcp_endpoint_v4(endpoint: &str) -> std::result::Result<(String, u16), String> {
-    if endpoint.trim().is_empty() {
-        return Err("host must not be empty".to_string());
-    }
-    if let Some(rest) = endpoint.strip_prefix('[') {
-        let (host, tail) = rest
-            .split_once(']')
-            .ok_or_else(|| "IPv6 endpoint must be [address] or [address]:port".to_string())?;
-        let port = match tail.strip_prefix(':') {
-            Some(port) => port
-                .parse::<u16>()
-                .map_err(|_| format!("invalid port: {port}"))?,
-            None if tail.is_empty() => PROLOGIX_DEFAULT_PORT,
-            _ => return Err("IPv6 endpoint must be [address] or [address]:port".to_string()),
-        };
-        if host.trim().is_empty() {
-            return Err("host must not be empty".to_string());
-        }
-        if port == 0 {
-            return Err("port must be in 1..=65535".to_string());
-        }
-        return Ok((host.to_string(), port));
-    }
-    let (host, port) = match endpoint.rsplit_once(':') {
-        Some((host, port)) if !host.contains(':') => {
-            let port = port
-                .parse::<u16>()
-                .map_err(|_| format!("invalid port: {port}"))?;
-            (host, port)
-        }
-        _ => (endpoint, PROLOGIX_DEFAULT_PORT),
-    };
-    let host = host.trim();
-    if host.is_empty() {
-        return Err("host must not be empty".to_string());
-    }
-    if port == 0 {
-        return Err("port must be in 1..=65535".to_string());
-    }
-    Ok((host.to_string(), port))
+        } => Connection::PrologixSerial {
+            path,
+            address,
+            baud_rate,
+            read_timeout_ms,
+        },
+    })
 }

--- a/src/config/render.rs
+++ b/src/config/render.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::connection::ConnectionUri;
 
 pub fn render_normalized_config(config: &Config) -> Result<String> {
     if config.version == 4 {
@@ -101,40 +102,42 @@ fn sensor_output_v4(config: &Config, index: u8) -> Result<SensorOutputV4> {
 }
 
 pub(crate) fn connection_uri(connection: &Connection) -> String {
-    match connection {
-        Connection::Tcpip { ip, port } if ip.contains(':') => format!("tcp://[{ip}]:{port}"),
-        Connection::Tcpip { ip, port } => format!("tcp://{ip}:{port}"),
-        Connection::Usbtmc { resource } => format!("visa:{resource}"),
-        Connection::Gpib { board, address } => format!("gpib://{board}/{address}"),
+    let uri = match connection {
+        Connection::Tcpip { ip, port } => ConnectionUri::Tcp {
+            host: ip.clone(),
+            port: *port,
+        },
+        Connection::Usbtmc { resource } => ConnectionUri::Visa {
+            resource: resource.clone(),
+        },
+        Connection::Gpib { board, address } => ConnectionUri::Gpib {
+            board: *board,
+            address: *address,
+        },
         Connection::PrologixTcp {
             host,
             port,
             address,
             read_timeout_ms,
-        } if host.contains(':') => {
-            format!(
-                "prologix-tcp://[{host}]:{port}?addr={address}&read_timeout_ms={read_timeout_ms}"
-            )
-        }
-        Connection::PrologixTcp {
-            host,
-            port,
-            address,
-            read_timeout_ms,
-        } => {
-            format!("prologix-tcp://{host}:{port}?addr={address}&read_timeout_ms={read_timeout_ms}")
-        }
+        } => ConnectionUri::PrologixTcp {
+            host: host.clone(),
+            port: *port,
+            address: *address,
+            read_timeout_ms: *read_timeout_ms,
+        },
         Connection::PrologixSerial {
             path,
             address,
             baud_rate,
             read_timeout_ms,
-        } => {
-            format!(
-                "prologix-serial://{path}?addr={address}&baud_rate={baud_rate}&read_timeout_ms={read_timeout_ms}"
-            )
-        }
-    }
+        } => ConnectionUri::PrologixSerial {
+            path: path.clone(),
+            address: *address,
+            baud_rate: *baud_rate,
+            read_timeout_ms: *read_timeout_ms,
+        },
+    };
+    uri.to_string()
 }
 
 fn lockin_output_v4(lockin: &Lockin, signal_channels: &[u8]) -> LockinOutputV4 {

--- a/src/config/tests/v4.rs
+++ b/src/config/tests/v4.rs
@@ -257,6 +257,27 @@ fn v4_prologix_connection_rejects_unknown_query_keys() {
 }
 
 #[test]
+fn v4_prologix_connection_rejects_duplicate_address_aliases() {
+    let text = v4_base().replacen(
+        "[data]",
+        "[generator]\nmodel = \"WF1946B\"\nconnection = \"prologix-tcp://192.168.1.50?addr=11&address=12\"\n\n[data]",
+        1,
+    );
+    match load_from_str(&text) {
+        ConfigLoad::Diagnostics(diag) => assert!(
+            diag.diagnostics.iter().any(|issue| {
+                issue.path.as_deref() == Some("generator.connection")
+                    && issue
+                        .message
+                        .contains("address must be specified only once")
+            }),
+            "missing duplicate Prologix address diagnostic: {diag:?}"
+        ),
+        other => panic!("expected v4 Prologix diagnostics, got {other:?}"),
+    }
+}
+
+#[test]
 fn v4_prologix_serial_rejects_zero_baud_rate() {
     let text = v4_base().replacen(
         "[data]",

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,0 +1,343 @@
+use std::fmt;
+
+pub(crate) const DEFAULT_PROLOGIX_PORT: u16 = 1234;
+pub(crate) const DEFAULT_PROLOGIX_BAUD_RATE: u32 = 115_200;
+pub(crate) const DEFAULT_PROLOGIX_READ_TIMEOUT_MS: u16 = 3000;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ConnectionDefaults {
+    pub(crate) prologix_read_timeout_ms: u64,
+}
+
+impl Default for ConnectionDefaults {
+    fn default() -> Self {
+        Self {
+            prologix_read_timeout_ms: u64::from(DEFAULT_PROLOGIX_READ_TIMEOUT_MS),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ConnectionUri {
+    Tcp {
+        host: String,
+        port: u16,
+    },
+    Visa {
+        resource: String,
+    },
+    Gpib {
+        board: u8,
+        address: u8,
+    },
+    PrologixTcp {
+        host: String,
+        port: u16,
+        address: u8,
+        read_timeout_ms: u16,
+    },
+    PrologixSerial {
+        path: String,
+        address: u8,
+        baud_rate: u32,
+        read_timeout_ms: u16,
+    },
+}
+
+impl ConnectionUri {
+    pub(crate) fn parse(value: &str, defaults: ConnectionDefaults) -> Result<Self, String> {
+        if let Some(endpoint) = value.strip_prefix("tcp://") {
+            let (host, port) = parse_host_port(endpoint, None, "TCP")?;
+            return Ok(Self::Tcp { host, port });
+        }
+        if let Some(resource) = value.strip_prefix("visa:") {
+            let resource = resource.trim();
+            if resource.is_empty() {
+                return Err("VISA resource must not be empty".to_string());
+            }
+            return Ok(Self::Visa {
+                resource: resource.to_string(),
+            });
+        }
+        if let Some(endpoint) = value.strip_prefix("gpib://") {
+            let (board, address) = endpoint
+                .split_once('/')
+                .ok_or_else(|| "GPIB connection must be gpib://board/address".to_string())?;
+            return Ok(Self::Gpib {
+                board: parse_u8(board, "GPIB board")?,
+                address: parse_gpib_address(address, "GPIB address")?,
+            });
+        }
+        if let Some(endpoint) = value.strip_prefix("prologix-tcp://") {
+            let (endpoint, query) = split_query(endpoint);
+            let params = parse_query_params(query)?;
+            validate_query_param_keys(&params, &["addr", "address", "read_timeout_ms"])?;
+            let address = parse_required_address_param(&params)?;
+            let read_timeout_ms = parse_timeout_param(&params, defaults.prologix_read_timeout_ms)?;
+            let (host, port) =
+                parse_host_port(endpoint, Some(DEFAULT_PROLOGIX_PORT), "Prologix TCP")?;
+            return Ok(Self::PrologixTcp {
+                host,
+                port,
+                address,
+                read_timeout_ms,
+            });
+        }
+        if let Some(endpoint) = value.strip_prefix("prologix-serial://") {
+            let (path, query) = split_query(endpoint);
+            let params = parse_query_params(query)?;
+            validate_query_param_keys(
+                &params,
+                &["addr", "address", "baud_rate", "read_timeout_ms"],
+            )?;
+            let address = parse_required_address_param(&params)?;
+            let read_timeout_ms = parse_timeout_param(&params, defaults.prologix_read_timeout_ms)?;
+            let baud_rate =
+                parse_optional_u32_param(&params, "baud_rate", DEFAULT_PROLOGIX_BAUD_RATE)?;
+            if baud_rate == 0 {
+                return Err("Prologix serial baud_rate must be positive".to_string());
+            }
+            let path = path.trim();
+            if path.is_empty() {
+                return Err("Prologix serial path must not be empty".to_string());
+            }
+            return Ok(Self::PrologixSerial {
+                path: path.to_string(),
+                address,
+                baud_rate,
+                read_timeout_ms,
+            });
+        }
+
+        Err(format!("unsupported connection string: {value}"))
+    }
+}
+
+impl fmt::Display for ConnectionUri {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Tcp { host, port } => write!(formatter, "tcp://{}:{port}", display_host(host)),
+            Self::Visa { resource } => write!(formatter, "visa:{resource}"),
+            Self::Gpib { board, address } => write!(formatter, "gpib://{board}/{address}"),
+            Self::PrologixTcp {
+                host,
+                port,
+                address,
+                read_timeout_ms,
+            } => write!(
+                formatter,
+                "prologix-tcp://{}:{port}?addr={address}&read_timeout_ms={read_timeout_ms}",
+                display_host(host)
+            ),
+            Self::PrologixSerial {
+                path,
+                address,
+                baud_rate,
+                read_timeout_ms,
+            } => write!(
+                formatter,
+                "prologix-serial://{path}?addr={address}&baud_rate={baud_rate}&read_timeout_ms={read_timeout_ms}"
+            ),
+        }
+    }
+}
+
+fn display_host(host: &str) -> String {
+    if host.contains(':') {
+        format!("[{host}]")
+    } else {
+        host.to_string()
+    }
+}
+
+fn parse_host_port(
+    endpoint: &str,
+    default_port: Option<u16>,
+    label: &str,
+) -> Result<(String, u16), String> {
+    let (host, port) = if let Some(rest) = endpoint.strip_prefix('[') {
+        let (host, tail) = rest
+            .split_once(']')
+            .ok_or_else(|| format!("{label} IPv6 endpoint must be [address]:port or [address]"))?;
+        let port = match tail.strip_prefix(':') {
+            Some(port) => parse_port(port, label)?,
+            None if tail.is_empty() => {
+                default_port.ok_or_else(|| format!("{label} endpoint must include a port"))?
+            }
+            _ => {
+                return Err(format!(
+                    "{label} IPv6 endpoint must be [address]:port or [address]"
+                ));
+            }
+        };
+        (host, port)
+    } else if let Some((host, port)) = endpoint.rsplit_once(':') {
+        if host.contains(':') {
+            return Err(format!(
+                "{label} IPv6 endpoint must use [address]:port or [address]"
+            ));
+        }
+        (host, parse_port(port, label)?)
+    } else {
+        let port = default_port.ok_or_else(|| format!("{label} endpoint must include a port"))?;
+        (endpoint, port)
+    };
+    let host = host.trim();
+    if host.is_empty() {
+        return Err(format!("{label} host must not be empty"));
+    }
+    Ok((host.to_string(), port))
+}
+
+fn parse_port(value: &str, label: &str) -> Result<u16, String> {
+    let port = value
+        .parse::<u16>()
+        .map_err(|_| format!("invalid {label} port: {value}"))?;
+    if port == 0 {
+        return Err(format!("{label} port must be in 1..=65535"));
+    }
+    Ok(port)
+}
+
+fn split_query(value: &str) -> (&str, Option<&str>) {
+    match value.split_once('?') {
+        Some((base, query)) => (base, Some(query)),
+        None => (value, None),
+    }
+}
+
+fn parse_query_params(query: Option<&str>) -> Result<Vec<(&str, &str)>, String> {
+    let Some(query) = query else {
+        return Ok(Vec::new());
+    };
+    query
+        .split('&')
+        .filter(|part| !part.is_empty())
+        .map(|part| {
+            part.split_once('=')
+                .ok_or_else(|| format!("query parameter '{part}' must be key=value"))
+        })
+        .collect()
+}
+
+fn validate_query_param_keys(params: &[(&str, &str)], allowed: &[&str]) -> Result<(), String> {
+    for (key, _) in params {
+        if !allowed.contains(key) {
+            return Err(format!("unsupported query parameter: {key}"));
+        }
+    }
+    Ok(())
+}
+
+fn parse_required_address_param(params: &[(&str, &str)]) -> Result<u8, String> {
+    let address = find_unique_query_param(params, &["addr", "address"], "Prologix address")?
+        .ok_or_else(|| "Prologix connection must include addr=0..30".to_string())?;
+    parse_gpib_address(address, "Prologix address")
+}
+
+fn parse_timeout_param(params: &[(&str, &str)], default: u64) -> Result<u16, String> {
+    let timeout = match find_unique_query_param(params, &["read_timeout_ms"], "read_timeout_ms")? {
+        Some(value) => value
+            .parse::<u64>()
+            .map_err(|_| format!("invalid read_timeout_ms: {value}"))?,
+        None => default,
+    };
+    validate_read_timeout(timeout)?;
+    Ok(timeout as u16)
+}
+
+fn validate_read_timeout(timeout: u64) -> Result<(), String> {
+    if (1..=3000).contains(&timeout) {
+        Ok(())
+    } else {
+        Err(format!(
+            "Prologix read_timeout_ms must be in 1..=3000 (got {timeout})"
+        ))
+    }
+}
+
+fn parse_optional_u32_param(
+    params: &[(&str, &str)],
+    key: &str,
+    default: u32,
+) -> Result<u32, String> {
+    let Some(value) = find_unique_query_param(params, &[key], key)? else {
+        return Ok(default);
+    };
+    value
+        .parse::<u32>()
+        .map_err(|_| format!("invalid {key}: {value}"))
+}
+
+fn find_unique_query_param<'a>(
+    params: &[(&str, &'a str)],
+    keys: &[&str],
+    label: &str,
+) -> Result<Option<&'a str>, String> {
+    let mut values = params
+        .iter()
+        .filter_map(|(key, value)| keys.contains(key).then_some(*value));
+    let value = values.next();
+    if values.next().is_some() {
+        return Err(format!("{label} must be specified only once"));
+    }
+    Ok(value)
+}
+
+fn parse_gpib_address(value: &str, label: &str) -> Result<u8, String> {
+    let address = parse_u8(value, label)?;
+    if address > 30 {
+        return Err(format!("{label} must be in 0..=30 (got {address})"));
+    }
+    Ok(address)
+}
+
+fn parse_u8(value: &str, label: &str) -> Result<u8, String> {
+    value
+        .parse::<u8>()
+        .map_err(|_| format!("invalid {label}: {value}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(value: &str) -> Result<ConnectionUri, String> {
+        ConnectionUri::parse(value, ConnectionDefaults::default())
+    }
+
+    #[test]
+    fn parses_and_canonicalizes_every_transport() {
+        let cases = [
+            ("tcp://scope.local:5025", "tcp://scope.local:5025"),
+            ("tcp://[2001:db8::1]:5025", "tcp://[2001:db8::1]:5025"),
+            ("visa:USB0::1234::INSTR", "visa:USB0::1234::INSTR"),
+            ("gpib://0/17", "gpib://0/17"),
+            (
+                "prologix-tcp://bridge.local?addr=17",
+                "prologix-tcp://bridge.local:1234?addr=17&read_timeout_ms=3000",
+            ),
+            (
+                "prologix-serial:///dev/ttyUSB0?address=11",
+                "prologix-serial:///dev/ttyUSB0?addr=11&baud_rate=115200&read_timeout_ms=3000",
+            ),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(parse(input).unwrap().to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn rejects_ambiguous_and_out_of_range_parameters() {
+        for input in [
+            "prologix-tcp://host?addr=17&address=18",
+            "prologix-tcp://host?addr=17&read_timeout_ms=10&read_timeout_ms=20",
+            "prologix-tcp://host?addr=31",
+            "prologix-serial:///dev/ttyUSB0?addr=1&baud_rate=0",
+            "tcp://2001:db8::1:5025",
+        ] {
+            assert!(parse(input).is_err(), "accepted {input}");
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ mod commands;
 #[cfg(feature = "hw-core")]
 mod communications;
 pub mod config;
+mod connection;
 mod constants;
 mod kerr;
 pub mod lockin;


### PR DESCRIPTION
## Summary
- centralize typed connection URI parsing and canonical rendering
- reuse the parser from config loading, instruments query, and benchmark sessions
- reject duplicate Prologix URI parameters consistently

## Verification
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --all-features --locked
- cargo test --workspace --no-default-features --locked
- cargo check --workspace --all-targets --all-features
- git diff --check