### PR TITLE
feat: add Prologix controller query API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "instruments"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "gpib-rs",
@@ -1345,7 +1345,7 @@ dependencies = [
 
 [[package]]
 name = "prologix-rs"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "serialport",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [dependencies]
-instruments = { path = "crates/instruments", default-features = false }
+instruments = { version = "0.2.4", path = "crates/instruments", default-features = false }
 anyhow = "1.0.104"
 serde = { version = "1.0.229", features = ["derive"] }
 toml = "1.1.4"

--- a/crates/instruments/Cargo.toml
+++ b/crates/instruments/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "instruments"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2024"
 
 [features]
@@ -10,8 +10,8 @@ prologix-tcp = ["dep:prologix-rs", "prologix-rs/tcp"]
 prologix-serial = ["dep:prologix-rs", "prologix-rs/serial"]
 
 [dependencies]
-gpib-rs = { path = "../gpib-rs", optional = true }
-prologix-rs = { path = "../prologix-rs", optional = true, default-features = false }
+gpib-rs = { version = "0.1.2", path = "../gpib-rs", optional = true }
+prologix-rs = { version = "0.1.2", path = "../prologix-rs", optional = true, default-features = false }
 anyhow = "1.0.104"
 
 [[example]]

--- a/crates/prologix-rs/Cargo.toml
+++ b/crates/prologix-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prologix-rs"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 description = "Small Prologix GPIB controller client for TCP and serial transports"
 license = "MIT OR Apache-2.0"

--- a/crates/prologix-rs/src/client.rs
+++ b/crates/prologix-rs/src/client.rs
@@ -1,7 +1,7 @@
 use std::io::{Read, Write};
 
 use crate::config::ControllerConfig;
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::wire::{read_response_bytes, write_line};
 
 pub struct Prologix<T> {
@@ -51,8 +51,20 @@ where
     }
 
     pub fn controller_version(&mut self) -> Result<String> {
-        self.controller_command("++ver")?;
+        self.controller_query("++ver")
+    }
+
+    /// Sends a controller query and reads its direct response.
+    ///
+    /// This does not issue `++read eoi` and therefore cannot be used to read an
+    /// instrument response from the GPIB bus.
+    pub fn controller_query(&mut self, command: &str) -> Result<String> {
+        validate_controller_query(command)?;
+        self.controller_command(command)?;
         let bytes = read_response_bytes(&mut self.io)?;
+        if bytes.is_empty() {
+            return Err(Error::EmptyControllerResponse);
+        }
         Ok(String::from_utf8(bytes)?
             .trim_end_matches(['\r', '\n'])
             .to_string())
@@ -74,4 +86,38 @@ where
         self.controller_command("++read eoi")?;
         read_response_bytes(&mut self.io)
     }
+}
+
+fn validate_controller_query(command: &str) -> Result<()> {
+    if command.trim().is_empty() {
+        return Err(Error::InvalidControllerQuery("command must not be empty"));
+    }
+    if command.contains(['\r', '\n']) {
+        return Err(Error::InvalidControllerQuery(
+            "command must contain exactly one line",
+        ));
+    }
+    let Some(controller_command) = command.strip_prefix("++") else {
+        return Err(Error::InvalidControllerQuery(
+            "command must start with '++'",
+        ));
+    };
+    let mut parts = controller_command.split_ascii_whitespace();
+    let name = parts.next().unwrap_or_default();
+    if name.is_empty() {
+        return Err(Error::InvalidControllerQuery(
+            "controller command name must not be empty",
+        ));
+    }
+    if name.eq_ignore_ascii_case("read") {
+        return Err(Error::InvalidControllerQuery(
+            "++read retrieves an instrument response; use query or query_bytes instead",
+        ));
+    }
+    if parts.next().is_some() {
+        return Err(Error::InvalidControllerQuery(
+            "controller queries must not include arguments; use controller_command for writes",
+        ));
+    }
+    Ok(())
 }

--- a/crates/prologix-rs/src/error.rs
+++ b/crates/prologix-rs/src/error.rs
@@ -10,6 +10,8 @@ pub enum Error {
     Io(io::Error),
     InvalidAddress(u8),
     InvalidReadTimeoutMs(u16),
+    InvalidControllerQuery(&'static str),
+    EmptyControllerResponse,
     ResponseNotUtf8(std::string::FromUtf8Error),
 }
 
@@ -25,6 +27,12 @@ impl fmt::Display for Error {
                 f,
                 "invalid Prologix read timeout {timeout_ms} ms; expected {MIN_READ_TIMEOUT_MS}..={MAX_READ_TIMEOUT_MS}"
             ),
+            Self::InvalidControllerQuery(reason) => {
+                write!(f, "invalid Prologix controller query: {reason}")
+            }
+            Self::EmptyControllerResponse => {
+                write!(f, "Prologix controller returned an empty response")
+            }
             Self::ResponseNotUtf8(err) => write!(f, "Prologix response is not UTF-8: {err}"),
         }
     }
@@ -35,7 +43,10 @@ impl std::error::Error for Error {
         match self {
             Self::Io(err) => Some(err),
             Self::ResponseNotUtf8(err) => Some(err),
-            Self::InvalidAddress(_) | Self::InvalidReadTimeoutMs(_) => None,
+            Self::InvalidAddress(_)
+            | Self::InvalidReadTimeoutMs(_)
+            | Self::InvalidControllerQuery(_)
+            | Self::EmptyControllerResponse => None,
         }
     }
 }

--- a/crates/prologix-rs/src/lib.rs
+++ b/crates/prologix-rs/src/lib.rs
@@ -1,8 +1,9 @@
 //! Prologix GPIB controller client.
 //!
 //! The crate keeps Prologix transport concerns separate from instrument drivers.
-//! Use [`Prologix::write`] for non-query SCPI commands and [`Prologix::query`]
-//! for commands that return a response.
+//! Use [`Prologix::write`] for non-query SCPI commands, [`Prologix::query`]
+//! for SCPI queries, and [`Prologix::controller_query`] for controller-local
+//! diagnostics such as `++ver`.
 
 mod client;
 mod config;

--- a/crates/prologix-rs/src/tests.rs
+++ b/crates/prologix-rs/src/tests.rs
@@ -89,6 +89,45 @@ fn controller_version_queries_the_adapter_without_gpib_read() {
 }
 
 #[test]
+fn controller_query_preserves_payload_whitespace_without_gpib_read() {
+    let io = MockIo::with_read(b"  17  \r\n");
+    let mut controller = Prologix::new(io, 17).unwrap();
+
+    let response = controller.controller_query("++addr").unwrap();
+
+    assert_eq!(response, "  17  ");
+    assert_eq!(controller.into_inner().written_text(), "++addr\n");
+}
+
+#[test]
+fn controller_query_rejects_instrument_reads_and_line_injection() {
+    for command in [
+        "*IDN?",
+        "++read eoi",
+        "++READ",
+        "++addr 5",
+        "++ver\n++addr",
+        "",
+    ] {
+        let mut controller = Prologix::new(MockIo::default(), 17).unwrap();
+        let error = controller.controller_query(command).unwrap_err();
+
+        assert!(matches!(error, Error::InvalidControllerQuery(_)));
+        assert_eq!(controller.into_inner().written_text(), "");
+    }
+}
+
+#[test]
+fn controller_query_rejects_an_empty_response() {
+    let mut controller = Prologix::new(MockIo::default(), 17).unwrap();
+
+    let error = controller.controller_query("++ver").unwrap_err();
+
+    assert!(matches!(error, Error::EmptyControllerResponse));
+    assert_eq!(controller.into_inner().written_text(), "++ver\n");
+}
+
+#[test]
 fn validates_address_and_timeout() {
     assert!(matches!(
         ControllerConfig::new(31),


### PR DESCRIPTION
## Summary
- add a controller-local query API without issuing an instrument `++read`
- validate controller query boundaries and reject empty responses
- route controller version checks through the generic API
- bump prologix-rs to 0.1.2 and instruments to 0.2.4 with explicit workspace dependency versions

## Verification
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --all-features --locked
- cargo test --workspace --no-default-features --locked
- dedicated prologix-rs tcp/serial/no-default tests
- instruments prologix-tcp/prologix-serial feature tests
- git diff --check