### PR TITLE
Docs M1: production foundation and Pages delivery

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -22,7 +22,7 @@ permissions:
 
 concurrency:
   group: docs-site-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   build:
@@ -77,15 +77,59 @@ jobs:
         working-directory: website
         run: pnpm test:e2e
 
-      - name: Upload static site and visual evidence
+      - name: Package GitHub Pages preview artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: website/out
+
+      - name: Upload visual evidence
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: pmoke-docs-${{ github.sha }}
+          name: pmoke-docs-visuals-${{ github.sha }}
           path: |
-            website/out
             website/test-results
             website/playwright-report
           if-no-files-found: warn
           include-hidden-files: true
           retention-days: 14
+
+  deploy:
+    name: Deploy GitHub Pages
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    concurrency:
+      group: github-pages
+      cancel-in-progress: false
+    outputs:
+      page_url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy artifact
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+  post-deploy:
+    name: Verify deployed site
+    needs: deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Node
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: "website/.node-version"
+
+      - name: Run deployment smoke test
+        run: node website/scripts/smoke-deployment.mjs "${{ needs.deploy.outputs.page_url }}"

--- a/crates/pmoke-web-wasm/Cargo.toml
+++ b/crates/pmoke-web-wasm/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 description = "Browser-safe signal preview primitives for the pmoke documentation site"
-license-file = "../../LICENSE"
+license = "Apache-2.0"
 repository = "https://github.com/Kerr-group/pmoke"
 
 [lib]

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -4,6 +4,10 @@
 # generated content
 .source
 
+# source route whose segment intentionally carries an image extension
+!/app/og.png/
+!/app/og.png/route.tsx
+
 # test & build
 /coverage
 /playwright-report/

--- a/website/app/(root)/layout.tsx
+++ b/website/app/(root)/layout.tsx
@@ -1,6 +1,36 @@
+import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
 import { FontVariables } from '@/components/font-variables';
+import { absoluteUrl, siteDescription, siteUrl, socialImage } from '@/lib/shared';
 import '../global.css';
+
+export const metadata: Metadata = {
+  metadataBase: new URL(`${siteUrl}/`),
+  title: 'pmoke | Documentation language',
+  description: siteDescription,
+  alternates: {
+    canonical: absoluteUrl('/'),
+    languages: {
+      en: absoluteUrl('/en'),
+      ja: absoluteUrl('/ja'),
+      'x-default': absoluteUrl('/'),
+    },
+  },
+  openGraph: {
+    type: 'website',
+    title: 'pmoke | Documentation language',
+    description: siteDescription,
+    url: absoluteUrl('/'),
+    siteName: 'pmoke',
+    images: [socialImage],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'pmoke | Documentation language',
+    description: siteDescription,
+    images: [socialImage.url],
+  },
+};
 
 export default function RootRouteLayout({ children }: { children: ReactNode }) {
   return (

--- a/website/app/[lang]/docs/[[...slug]]/page.tsx
+++ b/website/app/[lang]/docs/[[...slug]]/page.tsx
@@ -11,7 +11,7 @@ import {
 } from 'fumadocs-ui/layouts/docs/page';
 import { getMDXComponents } from '@/components/mdx';
 import { getPageMarkdownUrl, source } from '@/lib/source';
-import { gitConfig } from '@/lib/shared';
+import { absoluteUrl, gitConfig, socialImage } from '@/lib/shared';
 
 type Params = { lang: string; slug?: string[] };
 
@@ -48,12 +48,31 @@ export async function generateMetadata({ params }: { params: Promise<Params> }):
   const { lang, slug } = await params;
   const page = source.getPage(slug, lang);
   if (!page) notFound();
+  const englishPage = source.getPage(slug, 'en');
+  const japanesePage = source.getPage(slug, 'ja');
+  const canonical = absoluteUrl(page.url);
+  const languages: Record<string, string> = {};
+  if (englishPage) {
+    languages.en = absoluteUrl(englishPage.url);
+    languages['x-default'] = absoluteUrl(englishPage.url);
+  }
+  if (japanesePage) languages.ja = absoluteUrl(japanesePage.url);
+
   return {
     title: page.data.title,
     description: page.data.description,
     alternates: {
-      canonical: page.url,
-      languages: { en: page.url.replace(`/${lang}/`, '/en/'), ja: page.url.replace(`/${lang}/`, '/ja/') },
+      canonical,
+      languages,
     },
+    openGraph: {
+      title: page.data.title,
+      description: page.data.description,
+      url: canonical,
+      locale: lang === 'ja' ? 'ja_JP' : 'en_US',
+      alternateLocale: lang === 'ja' ? ['en_US'] : ['ja_JP'],
+      images: [socialImage],
+    },
+    twitter: { title: page.data.title, description: page.data.description, images: [socialImage.url] },
   };
 }

--- a/website/app/[lang]/layout.tsx
+++ b/website/app/[lang]/layout.tsx
@@ -2,14 +2,28 @@ import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
 import { notFound } from 'next/navigation';
 import { FontVariables } from '@/components/font-variables';
+import { SiteThemeProvider } from '@/components/site-theme-provider';
 import { isLanguage, languages } from '@/lib/i18n';
-import { siteDescription, siteOrigin } from '@/lib/shared';
+import { siteDescription, siteUrl, socialImage } from '@/lib/shared';
 import '../global.css';
 
 export const metadata: Metadata = {
-  metadataBase: new URL(`${siteOrigin}/pmoke/`),
+  metadataBase: new URL(`${siteUrl}/`),
   title: { default: 'pmoke', template: '%s | pmoke' },
   description: siteDescription,
+  applicationName: 'pmoke',
+  category: 'science',
+  openGraph: {
+    type: 'website',
+    siteName: 'pmoke',
+    description: siteDescription,
+    images: [socialImage],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    description: siteDescription,
+    images: [socialImage.url],
+  },
 };
 
 export function generateStaticParams() {
@@ -29,7 +43,7 @@ export default async function LocaleLayout({
   return (
     <html lang={lang} className={FontVariables} suppressHydrationWarning>
       <body>
-        {children}
+        <SiteThemeProvider>{children}</SiteThemeProvider>
       </body>
     </html>
   );

--- a/website/app/[lang]/page.tsx
+++ b/website/app/[lang]/page.tsx
@@ -1,8 +1,11 @@
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import { Activity, ArrowRight, BookOpen, CodeXml, Cpu, Search, Terminal } from 'lucide-react';
 import { notFound } from 'next/navigation';
 import { SignalHero } from '@/components/signal-hero';
+import { ThemeToggle } from '@/components/theme-toggle';
 import { isLanguage } from '@/lib/i18n';
+import { absoluteUrl, siteDescription, socialImage } from '@/lib/shared';
 
 const copy = {
   en: {
@@ -13,6 +16,9 @@ const copy = {
     docs: 'Read the docs',
     quickstart: 'Quickstart',
     signal: 'Live Wasm signal preview',
+    toggleTheme: 'Toggle color theme',
+    lightTheme: 'Switch to light theme',
+    darkTheme: 'Switch to dark theme',
     cards: [
       ['Instrument control', 'Typed TCP/IP, GPIB, and Prologix transports.', 'terminal'],
       ['Analysis pipeline', 'Reference, sensor, lock-in, phase, and Kerr stages.', 'activity'],
@@ -26,6 +32,9 @@ const copy = {
     docs: 'ドキュメント',
     quickstart: 'クイックスタート',
     signal: 'Wasm 信号プレビュー',
+    toggleTheme: 'カラーテーマ切替',
+    lightTheme: 'ライトテーマへ切替',
+    darkTheme: 'ダークテーマへ切替',
     cards: [
       ['装置制御', 'TCP/IP、GPIB、Prologix の型付き通信。', 'terminal'],
       ['解析パイプライン', 'Reference、sensor、lock-in、phase、Kerr の連続処理。', 'activity'],
@@ -53,6 +62,7 @@ export default async function HomePage({ params }: { params: Promise<{ lang: str
           <Link href={`/${lang === 'en' ? 'ja' : 'en'}`} lang={lang === 'en' ? 'ja' : 'en'}>
             {lang === 'en' ? '日本語' : 'English'}
           </Link>
+          <ThemeToggle toggleLabel={text.toggleTheme} lightLabel={text.lightTheme} darkLabel={text.darkTheme} />
           <a href="https://github.com/Kerr-group/pmoke" aria-label="GitHub"><CodeXml aria-hidden="true" /></a>
         </nav>
       </header>
@@ -79,4 +89,37 @@ export default async function HomePage({ params }: { params: Promise<{ lang: str
       </section>
     </main>
   );
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ lang: string }>;
+}): Promise<Metadata> {
+  const { lang } = await params;
+  if (!isLanguage(lang)) notFound();
+  const title = lang === 'ja' ? 'pmoke | パルス MOKE 精密信号ラボ' : 'pmoke | Pulsed-MOKE precision signal lab';
+  const canonical = absoluteUrl(`/${lang}`);
+
+  return {
+    title: { absolute: title },
+    description: siteDescription,
+    alternates: {
+      canonical,
+      languages: {
+        en: absoluteUrl('/en'),
+        ja: absoluteUrl('/ja'),
+        'x-default': absoluteUrl('/'),
+      },
+    },
+    openGraph: {
+      title,
+      description: siteDescription,
+      url: canonical,
+      locale: lang === 'ja' ? 'ja_JP' : 'en_US',
+      alternateLocale: lang === 'ja' ? ['en_US'] : ['ja_JP'],
+      images: [socialImage],
+    },
+    twitter: { title, description: siteDescription, images: [socialImage.url] },
+  };
 }

--- a/website/app/global.css
+++ b/website/app/global.css
@@ -13,6 +13,41 @@
   --amber: #f0b84e;
   --line: color-mix(in srgb, currentColor 14%, transparent);
   --radius: 6px;
+  --color-fd-background: #f2f5f3;
+  --color-fd-foreground: #101517;
+  --color-fd-muted: #e8edeb;
+  --color-fd-muted-foreground: #52605d;
+  --color-fd-popover: #f8faf9;
+  --color-fd-popover-foreground: #172023;
+  --color-fd-card: #edf1ef;
+  --color-fd-card-foreground: #101517;
+  --color-fd-border: rgba(36, 51, 53, 0.18);
+  --color-fd-primary: #087b7b;
+  --color-fd-primary-foreground: #f5ffff;
+  --color-fd-secondary: #e1e8e5;
+  --color-fd-secondary-foreground: #101517;
+  --color-fd-accent: rgba(8, 123, 123, 0.11);
+  --color-fd-accent-foreground: #075e60;
+  --color-fd-ring: #087b7b;
+}
+
+.dark {
+  --color-fd-background: #101517;
+  --color-fd-foreground: #edf2f0;
+  --color-fd-muted: #182124;
+  --color-fd-muted-foreground: #a2afac;
+  --color-fd-popover: #151d20;
+  --color-fd-popover-foreground: #edf2f0;
+  --color-fd-card: #151d20;
+  --color-fd-card-foreground: #edf2f0;
+  --color-fd-border: rgba(170, 190, 187, 0.17);
+  --color-fd-primary: #16d9d1;
+  --color-fd-primary-foreground: #071314;
+  --color-fd-secondary: #1c272a;
+  --color-fd-secondary-foreground: #edf2f0;
+  --color-fd-accent: rgba(22, 217, 209, 0.12);
+  --color-fd-accent-foreground: #58ebe5;
+  --color-fd-ring: #16d9d1;
 }
 
 html {
@@ -75,6 +110,14 @@ button:focus-visible {
   color: var(--cyan);
 }
 
+.brand-context {
+  padding-left: 0.55rem;
+  border-left: 1px solid var(--color-fd-border);
+  color: var(--color-fd-muted-foreground);
+  font-size: 0.62rem;
+  font-weight: 650;
+}
+
 .locale-index {
   width: min(92vw, 680px);
   min-height: 100vh;
@@ -132,6 +175,24 @@ button:focus-visible {
 }
 .site-header nav a:hover { color: var(--cyan); }
 .site-header nav svg { width: 16px; height: 16px; }
+
+.theme-toggle {
+  width: 34px;
+  height: 34px;
+  display: inline-grid;
+  place-items: center;
+  padding: 0;
+  border: 1px solid #536165;
+  background: transparent;
+  color: #dce5e2;
+  cursor: pointer;
+}
+
+.theme-toggle:hover { border-color: var(--cyan); color: var(--cyan); }
+.theme-toggle svg { grid-area: 1 / 1; width: 16px; height: 16px; }
+.theme-icon-to-light { display: none; }
+.dark .theme-icon-to-light { display: block; }
+.dark .theme-icon-to-dark { display: none; }
 
 .hero-band {
   position: relative;
@@ -267,10 +328,41 @@ button:focus-visible {
 .capability-grid h2 { margin: 2.6rem 0 0.7rem; font-size: 1.05rem; }
 .capability-grid p { max-width: 34ch; margin: 0; color: #94a19f; line-height: 1.65; }
 
+html:not(.dark) .home-shell { background: #eef3f1; color: #101517; }
+html:not(.dark) .site-header { border-color: #b7c2bf; }
+html:not(.dark) .site-header nav a { color: #3b4b4c; }
+html:not(.dark) .site-header nav a:hover { color: #087b7b; }
+html:not(.dark) .signal-stage { background: #e4ebe8; }
+html:not(.dark) .signal-stage::after { background: rgba(242, 245, 243, 0.24); }
+html:not(.dark) .signal-hud { color: #536563; }
+html:not(.dark) .signal-hud .wasm-state { color: #137946; }
+html:not(.dark) .hero-copy h1,
+html:not(.dark) .hero-lead { color: #101517; }
+html:not(.dark) .hero-description { color: #52615f; }
+html:not(.dark) .hero-actions a { border-color: #82908e; color: #172023; }
+html:not(.dark) .hero-actions .primary-action { border-color: #087b7b; background: #087b7b; color: #f5ffff; }
+html:not(.dark) .theme-toggle { border-color: #82908e; color: #172023; }
+html:not(.dark) .capability-grid { border-color: #b7c2bf; }
+html:not(.dark) .capability-grid article { border-color: #b7c2bf; }
+html:not(.dark) .capability-grid p { color: #52615f; }
+
+#nd-docs-layout { background: var(--color-fd-background); }
+
+#nd-sidebar,
+#nd-tocnav {
+  backdrop-filter: blur(14px);
+}
+
+.prose pre {
+  border: 1px solid var(--color-fd-border);
+  border-radius: var(--radius);
+}
+
 @media (max-width: 720px) {
   .locale-index h1 { font-size: 4.4rem; }
   .site-header { width: min(100% - 28px, 1440px); height: 60px; }
   .site-header nav a:first-child { display: none; }
+  .site-header nav { gap: 0.7rem; }
   .hero-band { min-height: 550px; height: calc(100svh - 112px); max-height: 720px; }
   .hero-copy { width: min(100% - 28px, 1440px); padding-bottom: 5rem; justify-content: flex-end; }
   .hero-copy h1 { font-size: 5rem; }

--- a/website/app/og.png/route.tsx
+++ b/website/app/og.png/route.tsx
@@ -1,0 +1,70 @@
+import { ImageResponse } from 'next/og';
+
+export const dynamic = 'force-static';
+
+const size = { width: 1200, height: 630 };
+const traces = [
+  { color: '#16d9d1', top: 392, turns: [-8, 17, -20, 13, -5, 21, -14, 8] },
+  { color: '#ed4f9a', top: 452, turns: [13, -12, 19, -16, 10, -8, 16, -11] },
+] as const;
+
+export function GET() {
+  return new ImageResponse(
+    <div
+      style={{
+        position: 'relative',
+        display: 'flex',
+        width: '100%',
+        height: '100%',
+        overflow: 'hidden',
+        background: '#101517',
+        color: '#f2f5f3',
+        fontFamily: 'sans-serif',
+      }}
+    >
+      {Array.from({ length: 11 }, (_, index) => (
+        <div
+          key={`vertical-${index}`}
+          style={{ position: 'absolute', left: index * 120, top: 0, width: 1, height: 630, background: '#263235' }}
+        />
+      ))}
+      {Array.from({ length: 6 }, (_, index) => (
+        <div
+          key={`horizontal-${index}`}
+          style={{ position: 'absolute', left: 0, top: index * 126, width: 1200, height: 1, background: '#263235' }}
+        />
+      ))}
+      <div style={{ position: 'absolute', left: 70, top: 62, display: 'flex', color: '#16d9d1', fontSize: 24 }}>
+        PRECISION SIGNAL LAB
+      </div>
+      <div style={{ position: 'absolute', left: 64, top: 126, display: 'flex', fontSize: 150, fontWeight: 800 }}>
+        pmoke
+      </div>
+      <div style={{ position: 'absolute', left: 72, top: 300, display: 'flex', fontSize: 31, color: '#aebbb8' }}>
+        Pulsed-MOKE acquisition · lock-in analysis · instrument control
+      </div>
+      {traces.flatMap((trace, traceIndex) =>
+        trace.turns.map((turn, index) => (
+          <div
+            key={`${trace.color}-${index}`}
+            style={{
+              position: 'absolute',
+              left: 68 + index * 132,
+              top: trace.top + turn,
+              width: 142,
+              height: 4,
+              background: trace.color,
+              transform: `rotate(${trace.turns[(index + 1) % trace.turns.length] - turn}deg)`,
+              transformOrigin: 'left center',
+              opacity: traceIndex === 0 ? 0.95 : 0.78,
+            }}
+          />
+        )),
+      )}
+      <div style={{ position: 'absolute', right: 70, bottom: 52, display: 'flex', color: '#55d187', fontSize: 22 }}>
+        RUST · WASM · STATIC
+      </div>
+    </div>,
+    size,
+  );
+}

--- a/website/app/robots.ts
+++ b/website/app/robots.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from 'next';
+import { absoluteUrl, basePath, siteOrigin } from '@/lib/shared';
+
+export const dynamic = 'force-static';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: `${basePath || ''}/`,
+    },
+    sitemap: absoluteUrl('/sitemap.xml'),
+    host: siteOrigin,
+  };
+}

--- a/website/app/sitemap.ts
+++ b/website/app/sitemap.ts
@@ -1,0 +1,60 @@
+import type { MetadataRoute } from 'next';
+import { languages } from '@/lib/i18n';
+import { source } from '@/lib/source';
+import { absoluteUrl } from '@/lib/shared';
+
+export const dynamic = 'force-static';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const rootLanguages = {
+    en: absoluteUrl('/en'),
+    ja: absoluteUrl('/ja'),
+    'x-default': absoluteUrl('/'),
+  };
+  const entries: MetadataRoute.Sitemap = [
+    {
+      url: absoluteUrl('/'),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+      alternates: { languages: rootLanguages },
+    },
+  ];
+  const seen = new Set<string>();
+
+  for (const language of languages) {
+    for (const page of source.getPages(language)) {
+      const key = page.slugs.join('/');
+      if (seen.has(key)) continue;
+      seen.add(key);
+      const english = source.getPage(page.slugs, 'en');
+      const japanese = source.getPage(page.slugs, 'ja');
+      const alternates: Record<string, string> = {};
+      if (english) {
+        alternates.en = absoluteUrl(english.url);
+        alternates['x-default'] = absoluteUrl(english.url);
+      }
+      if (japanese) alternates.ja = absoluteUrl(japanese.url);
+
+      for (const localizedPage of [english, japanese]) {
+        if (!localizedPage) continue;
+        entries.push({
+          url: absoluteUrl(localizedPage.url),
+          changeFrequency: 'weekly',
+          priority: localizedPage.slugs.length === 0 ? 1 : 0.8,
+          alternates: { languages: alternates },
+        });
+      }
+    }
+  }
+
+  entries.push(
+    ...languages.map((language) => ({
+      url: absoluteUrl(`/${language}`),
+      changeFrequency: 'weekly' as const,
+      priority: 1,
+      alternates: { languages: rootLanguages },
+    })),
+  );
+
+  return entries;
+}

--- a/website/components/provider.tsx
+++ b/website/components/provider.tsx
@@ -9,7 +9,7 @@ export function Provider({ children, lang }: { children: ReactNode; lang: Langua
     <RootProvider
       search={{ SearchDialog }}
       i18n={i18nUI.provider(lang)}
-      theme={{ attribute: 'class', defaultTheme: 'dark', enableSystem: true }}
+      theme={{ enabled: false }}
     >
       {children}
     </RootProvider>

--- a/website/components/signal-hero.tsx
+++ b/website/components/signal-hero.tsx
@@ -4,9 +4,9 @@ import { useEffect, useRef, useState } from 'react';
 import { basePath } from '@/lib/shared';
 
 const CHANNELS = [
-  { offset: 1, color: '#e7edf0', width: 1.15 },
-  { offset: 2, color: '#16d9d1', width: 1.8 },
-  { offset: 3, color: '#ed4f9a', width: 1.45 },
+  { offset: 1, darkColor: '#e7edf0', lightColor: '#44575a', width: 1.15 },
+  { offset: 2, darkColor: '#16d9d1', lightColor: '#087b7b', width: 1.8 },
+  { offset: 3, darkColor: '#ed4f9a', lightColor: '#bd286f', width: 1.45 },
 ] as const;
 const FALLBACK_SIGNAL = fallbackSignal(360);
 
@@ -54,10 +54,11 @@ export function SignalHero({ label }: { label: string }) {
         }
         context.setTransform(ratio, 0, 0, ratio, 0, 0);
         context.clearRect(0, 0, rect.width, rect.height);
-        drawGrid(context, rect.width, rect.height);
+        const dark = document.documentElement.classList.contains('dark');
+        drawGrid(context, rect.width, rect.height, dark);
         const values = dataRef.current ?? FALLBACK_SIGNAL;
         const phase = reducedMotion ? 0 : frame * 0.0018;
-        drawSignals(context, values, rect.width, rect.height, phase);
+        drawSignals(context, values, rect.width, rect.height, phase, dark);
         frame += 1;
       }
       animation = requestAnimationFrame(draw);
@@ -78,18 +79,25 @@ export function SignalHero({ label }: { label: string }) {
   );
 }
 
-function drawGrid(context: CanvasRenderingContext2D, width: number, height: number) {
-  context.strokeStyle = 'rgba(145, 164, 174, 0.13)';
+function drawGrid(context: CanvasRenderingContext2D, width: number, height: number, dark: boolean) {
+  context.strokeStyle = dark ? 'rgba(145, 164, 174, 0.13)' : 'rgba(40, 67, 68, 0.14)';
   context.lineWidth = 1;
   for (let x = 0; x <= width; x += 48) { context.beginPath(); context.moveTo(x, 0); context.lineTo(x, height); context.stroke(); }
   for (let y = 0; y <= height; y += 40) { context.beginPath(); context.moveTo(0, y); context.lineTo(width, y); context.stroke(); }
 }
 
-function drawSignals(context: CanvasRenderingContext2D, values: Float64Array, width: number, height: number, phase: number) {
+function drawSignals(
+  context: CanvasRenderingContext2D,
+  values: Float64Array,
+  width: number,
+  height: number,
+  phase: number,
+  dark: boolean,
+) {
   const count = values.length / 4;
   for (const channel of CHANNELS) {
     context.beginPath();
-    context.strokeStyle = channel.color;
+    context.strokeStyle = dark ? channel.darkColor : channel.lightColor;
     context.lineWidth = channel.width;
     context.globalAlpha = channel.offset === 1 ? 0.36 : 0.92;
     for (let index = 0; index < count; index += 1) {

--- a/website/components/site-theme-provider.tsx
+++ b/website/components/site-theme-provider.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { ThemeProvider } from 'next-themes';
+import type { ReactNode } from 'react';
+
+export function SiteThemeProvider({ children }: { children: ReactNode }) {
+  return (
+    <ThemeProvider
+      attribute="class"
+      defaultTheme="dark"
+      enableSystem
+      storageKey="pmoke-theme"
+      disableTransitionOnChange
+    >
+      {children}
+    </ThemeProvider>
+  );
+}

--- a/website/components/theme-toggle.tsx
+++ b/website/components/theme-toggle.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { Moon, Sun } from 'lucide-react';
+import { useTheme } from 'next-themes';
+import { useSyncExternalStore } from 'react';
+
+const subscribe = () => () => {};
+
+export function ThemeToggle({
+  toggleLabel,
+  lightLabel,
+  darkLabel,
+}: {
+  toggleLabel: string;
+  lightLabel: string;
+  darkLabel: string;
+}) {
+  const { theme, resolvedTheme, setTheme } = useTheme();
+  const mounted = useSyncExternalStore(subscribe, () => true, () => false);
+  const currentTheme = theme === 'system' ? resolvedTheme : theme;
+  const nextTheme = currentTheme === 'dark' ? 'light' : 'dark';
+  const label = mounted ? (nextTheme === 'light' ? lightLabel : darkLabel) : toggleLabel;
+
+  return (
+    <button
+      type="button"
+      className="theme-toggle"
+      aria-label={label}
+      title={label}
+      onClick={() => setTheme(nextTheme)}
+    >
+      <Sun className="theme-icon-to-light" aria-hidden="true" />
+      <Moon className="theme-icon-to-dark" aria-hidden="true" />
+    </button>
+  );
+}

--- a/website/lib/layout.shared.tsx
+++ b/website/lib/layout.shared.tsx
@@ -1,5 +1,5 @@
 import type { BaseLayoutProps } from 'fumadocs-ui/layouts/shared';
-import { Activity, BookOpen, Terminal } from 'lucide-react';
+import { Activity, CodeXml, House } from 'lucide-react';
 import { appName, gitConfig } from './shared';
 
 export function baseOptions(lang: 'en' | 'ja'): BaseLayoutProps {
@@ -9,22 +9,26 @@ export function baseOptions(lang: 'en' | 'ja'): BaseLayoutProps {
         <span className="brand-lockup">
           <Activity aria-hidden="true" size={18} />
           <span>{appName}</span>
+          <span className="brand-context">DOCS</span>
         </span>
       ),
       url: `/${lang}`,
     },
     links: [
       {
-        text: lang === 'ja' ? '概要' : 'Overview',
-        url: `/${lang}/docs`,
-        icon: <BookOpen aria-hidden="true" />,
+        text: lang === 'ja' ? 'ホーム' : 'Home',
+        url: `/${lang}`,
+        icon: <House aria-hidden="true" />,
       },
       {
-        text: lang === 'ja' ? 'クイックスタート' : 'Quickstart',
-        url: `/${lang}/docs/quickstart`,
-        icon: <Terminal aria-hidden="true" />,
+        type: 'icon',
+        text: 'GitHub',
+        label: 'GitHub',
+        url: `https://github.com/${gitConfig.user}/${gitConfig.repo}`,
+        external: true,
+        icon: <CodeXml aria-hidden="true" />,
       },
     ],
-    githubUrl: `https://github.com/${gitConfig.user}/${gitConfig.repo}`,
+    i18n: true,
   };
 }

--- a/website/lib/shared.ts
+++ b/website/lib/shared.ts
@@ -3,10 +3,27 @@ export const docsRoute = '/docs';
 export const docsContentRoute = '/llm';
 export const siteDescription =
   'Precision pulsed-MOKE acquisition, lock-in analysis, and instrument control.';
-export const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? '/pmoke';
-export const siteOrigin = 'https://kerr-group.github.io';
+const configuredBasePath = process.env.NEXT_PUBLIC_BASE_PATH ?? '/pmoke';
+export const basePath = configuredBasePath === '/' ? '' : configuredBasePath.replace(/\/$/, '');
+export const siteOrigin = (process.env.NEXT_PUBLIC_SITE_ORIGIN ?? 'https://kerr-group.github.io').replace(
+  /\/$/,
+  '',
+);
+export const siteUrl = `${siteOrigin}${basePath}`;
 
-// fill this with your actual GitHub info, for example:
+export function absoluteUrl(pathname = '/'): string {
+  const normalized = pathname.replace(/^\/+|\/+$/g, '');
+  const path = pathname === '/' ? '/' : `/${normalized}${/\.[^/]+$/.test(normalized) ? '' : '/'}`;
+  return `${siteUrl}${path}`;
+}
+
+export const socialImage = {
+  url: absoluteUrl('/og.png'),
+  width: 1200,
+  height: 630,
+  alt: 'pmoke pulsed-MOKE precision signal lab',
+};
+
 export const gitConfig = {
   user: 'Kerr-group',
   repo: 'pmoke',

--- a/website/lib/source.ts
+++ b/website/lib/source.ts
@@ -1,5 +1,5 @@
 import { loader } from 'fumadocs-core/source';
-import { basePath, docsContentRoute, docsRoute, siteOrigin } from './shared';
+import { absoluteUrl, basePath, docsContentRoute, docsRoute } from './shared';
 import { defineDocs } from 'fumadocs-mdx/macro';
 import { metaSchema, pageSchema } from 'fumadocs-core/source/schema';
 import { i18n } from './i18n';
@@ -42,7 +42,7 @@ function withBasePath(path: string): string {
 
 export async function getLLMText(page: (typeof source)['$inferPage']) {
   const processed = await page.data.getText('processed');
-  const canonical = new URL(`${basePath}${page.url}/`, siteOrigin);
+  const canonical = absoluteUrl(page.url);
 
   return `# ${page.data.title} (${canonical})
 

--- a/website/package.json
+++ b/website/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "npm run build:wasm && next build && node scripts/postbuild.mjs",
     "build:site": "next build && node scripts/postbuild.mjs",
-    "build:wasm": "wasm-pack build ../crates/pmoke-web-wasm --target web --out-dir ../../website/public/wasm --release -- --locked",
+    "build:wasm": "wasm-pack build ../crates/pmoke-web-wasm --target web --out-dir ../../website/public/wasm --release --no-pack -- --locked",
     "dev": "pnpm build:wasm && next dev",
     "start": "node scripts/serve-basepath.mjs",
     "types:check": "next typegen && tsc --noEmit",
@@ -25,11 +25,13 @@
     "fumadocs-ui": "npm:@fumadocs/base-ui@16.14.0",
     "lucide-react": "1.27.0",
     "next": "16.2.12",
+    "next-themes": "0.4.6",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "zod": "4.4.3"
   },
   "devDependencies": {
+    "@axe-core/playwright": "4.12.1",
     "@playwright/test": "1.62.1",
     "@tailwindcss/postcss": "4.3.3",
     "@types/mdx": "2.0.14",

--- a/website/playwright.config.ts
+++ b/website/playwright.config.ts
@@ -16,6 +16,8 @@ export default defineConfig({
   },
   projects: [
     { name: 'desktop-chromium', use: { ...devices['Desktop Chrome'], viewport: { width: 1440, height: 900 } } },
+    { name: 'wide-chromium', use: { ...devices['Desktop Chrome'], viewport: { width: 1920, height: 1080 } } },
+    { name: 'tablet-chromium', use: { ...devices['Desktop Chrome'], viewport: { width: 768, height: 1024 } } },
     { name: 'mobile-chromium', use: { ...devices['Pixel 7'], viewport: { width: 360, height: 800 } } },
   ],
   webServer: {

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       next:
         specifier: 16.2.12
         version: 16.2.12(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.62.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next-themes:
+        specifier: 0.4.6
+        version: 0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -37,6 +40,9 @@ importers:
         specifier: 4.4.3
         version: 4.4.3
     devDependencies:
+      '@axe-core/playwright':
+        specifier: 4.12.1
+        version: 4.12.1(playwright-core@1.62.1)
       '@playwright/test':
         specifier: 1.62.1
         version: 1.62.1
@@ -76,6 +82,11 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@axe-core/playwright@4.12.1':
+    resolution: {integrity: sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -3094,6 +3105,11 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@axe-core/playwright@4.12.1(playwright-core@1.62.1)':
+    dependencies:
+      axe-core: 4.12.1
+      playwright-core: 1.62.1
 
   '@babel/code-frame@7.29.7':
     dependencies:

--- a/website/scripts/serve-basepath.mjs
+++ b/website/scripts/serve-basepath.mjs
@@ -9,7 +9,8 @@ const port = Number(process.env.PORT ?? 4173);
 const mime = new Map([
   ['.css', 'text/css; charset=utf-8'], ['.html', 'text/html; charset=utf-8'],
   ['.js', 'text/javascript; charset=utf-8'], ['.json', 'application/json; charset=utf-8'],
-  ['.txt', 'text/plain; charset=utf-8'], ['.wasm', 'application/wasm'], ['.woff2', 'font/woff2'],
+  ['.png', 'image/png'], ['.txt', 'text/plain; charset=utf-8'],
+  ['.wasm', 'application/wasm'], ['.woff2', 'font/woff2'], ['.xml', 'application/xml; charset=utf-8'],
 ]);
 
 createServer(async (request, response) => {

--- a/website/scripts/smoke-deployment.mjs
+++ b/website/scripts/smoke-deployment.mjs
@@ -1,0 +1,39 @@
+const deploymentUrl = process.argv[2];
+if (!deploymentUrl) throw new Error('deployment URL is required');
+
+const root = new URL(deploymentUrl.endsWith('/') ? deploymentUrl : `${deploymentUrl}/`);
+const checks = [
+  { path: 'en/', contains: '<h1>pmoke</h1>' },
+  { path: 'ja/', contains: '精密信号ラボ' },
+  { path: 'en/docs/quickstart/', contains: 'Quickstart' },
+  { path: 'ja/docs/quickstart/', contains: 'クイックスタート' },
+  { path: 'api/search', contains: 'Kerr' },
+  { path: 'llms.txt', contains: 'https://kerr-group.github.io/pmoke/en/docs/' },
+  { path: 'sitemap.xml', contains: '<loc>https://kerr-group.github.io/pmoke/en/' },
+  { path: 'robots.txt', contains: 'Sitemap: https://kerr-group.github.io/pmoke/sitemap.xml' },
+  { path: 'wasm/pmoke_web_wasm_bg.wasm', contentType: 'application/wasm' },
+];
+
+for (const check of checks) {
+  const url = new URL(check.path, root);
+  let lastError;
+  for (let attempt = 1; attempt <= 5; attempt += 1) {
+    try {
+      const response = await fetch(url, { cache: 'no-store' });
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      if (check.contentType && !response.headers.get('content-type')?.includes(check.contentType)) {
+        throw new Error(`expected ${check.contentType}, received ${response.headers.get('content-type')}`);
+      }
+      if (check.contains && !(await response.text()).includes(check.contains)) {
+        throw new Error(`missing marker: ${check.contains}`);
+      }
+      lastError = undefined;
+      break;
+    } catch (error) {
+      lastError = error;
+      if (attempt < 5) await new Promise((resolve) => setTimeout(resolve, attempt * 2_000));
+    }
+  }
+  if (lastError) throw new Error(`deployment smoke failed for ${url}: ${lastError.message}`);
+  console.log(`Verified ${url}`);
+}

--- a/website/scripts/verify-export.mjs
+++ b/website/scripts/verify-export.mjs
@@ -18,6 +18,9 @@ const required = [
   'wasm/pmoke_web_wasm.js',
   'wasm/pmoke_web_wasm_bg.wasm',
   'workers/signal.worker.js',
+  'og.png',
+  'robots.txt',
+  'sitemap.xml',
   '.nojekyll',
   '_meta/payload.json',
 ];
@@ -26,10 +29,26 @@ for (const relative of required) await access(path.join(output, relative));
 
 const English = await readFile(path.join(output, 'en/index.html'), 'utf8');
 const Japanese = await readFile(path.join(output, 'ja/index.html'), 'utf8');
+const JapaneseQuickstart = await readFile(path.join(output, 'ja/docs/quickstart/index.html'), 'utf8');
+const sitemap = await readFile(path.join(output, 'sitemap.xml'), 'utf8');
+const robots = await readFile(path.join(output, 'robots.txt'), 'utf8');
 if (!English.includes('<html lang="en"')) throw new Error('English lang metadata is missing');
 if (!Japanese.includes('<html lang="ja"')) throw new Error('Japanese lang metadata is missing');
 if (!English.includes('/pmoke/_next/')) throw new Error('GitHub Pages basePath is missing');
 if (!Japanese.includes('精密信号ラボ')) throw new Error('Japanese home content is missing');
+if (!JapaneseQuickstart.includes('https://kerr-group.github.io/pmoke/ja/docs/quickstart/')) {
+  throw new Error('Canonical project URL is missing');
+}
+if (!JapaneseQuickstart.includes('hrefLang="x-default"')) throw new Error('x-default metadata is missing');
+if (!JapaneseQuickstart.includes('https://kerr-group.github.io/pmoke/og.png')) {
+  throw new Error('Open Graph image is missing');
+}
+if (!sitemap.includes('https://kerr-group.github.io/pmoke/en/docs/quickstart/')) {
+  throw new Error('Localized sitemap entry is missing');
+}
+if (!robots.includes('Sitemap: https://kerr-group.github.io/pmoke/sitemap.xml\n')) {
+  throw new Error('Robots sitemap declaration is missing');
+}
 
 const wasm = await stat(path.join(output, 'wasm/pmoke_web_wasm_bg.wasm'));
 if (wasm.size > 200 * 1024) throw new Error(`M0 Wasm budget exceeded: ${wasm.size} bytes`);

--- a/website/tests/foundation.spec.ts
+++ b/website/tests/foundation.spec.ts
@@ -1,0 +1,132 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test } from '@playwright/test';
+
+const locales = ['en', 'ja'] as const;
+const themes = ['dark', 'light'] as const;
+
+for (const locale of locales) {
+  for (const theme of themes) {
+    test(`${locale} ${theme} foundation remains responsive`, async ({ page }, testInfo) => {
+      await page.addInitScript((selectedTheme) => {
+        window.localStorage.setItem('pmoke-theme', selectedTheme);
+      }, theme);
+
+      await page.goto(`/pmoke/${locale}/`);
+      await expect(page.locator('html')).toHaveClass(new RegExp(`(^|\\s)${theme}(\\s|$)`));
+      await expect(page.locator('h1')).toHaveText('pmoke');
+      expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBeTruthy();
+      await page.screenshot({ path: testInfo.outputPath(`${locale}-${theme}-home.png`), fullPage: true });
+
+      await page.goto(`/pmoke/${locale}/docs/quickstart/`);
+      await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+      expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBeTruthy();
+      await page.screenshot({ path: testInfo.outputPath(`${locale}-${theme}-docs.png`), fullPage: true });
+    });
+  }
+}
+
+test('representative routes have no serious accessibility violations', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'desktop-chromium', 'single-browser accessibility gate');
+
+  for (const route of ['/pmoke/en/', '/pmoke/ja/', '/pmoke/en/docs/quickstart/', '/pmoke/ja/docs/quickstart/']) {
+    await page.goto(route);
+    const result = await new AxeBuilder({ page }).analyze();
+    const blocking = result.violations.filter(
+      (violation) => violation.impact === 'serious' || violation.impact === 'critical',
+    );
+    expect(blocking, `${route}: ${blocking.map((violation) => violation.id).join(', ')}`).toEqual([]);
+  }
+});
+
+test('documentation language selection preserves the current slug', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'desktop-chromium', 'single-browser interaction gate');
+
+  await page.goto('/pmoke/en/docs/quickstart/');
+  await page.getByRole('button', { name: 'Choose a language' }).click();
+  await page.getByRole('button', { name: '日本語' }).click();
+  await expect(page).toHaveURL(/\/pmoke\/ja\/docs\/quickstart\/$/);
+  await expect(page.getByRole('heading', { level: 1, name: 'クイックスタート' })).toBeVisible();
+});
+
+test('home theme selection persists into documentation', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'desktop-chromium', 'single-browser interaction gate');
+
+  await page.addInitScript((selectedTheme) => {
+    if (!window.localStorage.getItem('pmoke-theme')) {
+      window.localStorage.setItem('pmoke-theme', selectedTheme);
+    }
+  }, 'dark');
+  await page.goto('/pmoke/en/');
+  await expect(page.locator('.theme-toggle')).toHaveAttribute('aria-label', 'Switch to light theme');
+  await page.locator('.theme-toggle').click();
+  await expect(page.locator('html')).toHaveClass(/(^|\s)light(\s|$)/);
+  await page.goto('/pmoke/en/docs/');
+  await expect(page.locator('html')).toHaveClass(/(^|\s)light(\s|$)/);
+});
+
+test('documentation remains readable without JavaScript', async ({ browser }, testInfo) => {
+  test.skip(testInfo.project.name !== 'desktop-chromium', 'single-browser progressive-enhancement gate');
+
+  const context = await browser.newContext({ javaScriptEnabled: false });
+  const page = await context.newPage();
+  await page.goto('http://127.0.0.1:4173/pmoke/ja/docs/quickstart/');
+  await expect(page.getByRole('heading', { level: 1, name: 'クイックスタート' })).toBeVisible();
+  await expect(page.locator('code').filter({ hasText: 'pmoke config init' })).toBeVisible();
+  await context.close();
+});
+
+test('reduced motion keeps the signal canvas static', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'desktop-chromium', 'single-browser reduced-motion gate');
+
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+  await page.goto('/pmoke/en/');
+  await expect(page.locator('.signal-stage')).toHaveAttribute('data-wasm', 'ready', { timeout: 15_000 });
+  const first = await page.locator('canvas').evaluate((canvas: HTMLCanvasElement) => canvas.toDataURL());
+  await page.waitForTimeout(150);
+  const second = await page.locator('canvas').evaluate((canvas: HTMLCanvasElement) => canvas.toDataURL());
+  expect(second).toBe(first);
+});
+
+test('all rendered internal links resolve beneath the project path', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'desktop-chromium', 'single-browser link gate');
+
+  const routes = ['/pmoke/', '/pmoke/en/', '/pmoke/ja/', '/pmoke/en/docs/', '/pmoke/ja/docs/quickstart/'];
+  const links = new Set<string>(routes);
+  for (const route of routes) {
+    await page.goto(route);
+    const rendered = await page.locator('a[href]').evaluateAll((anchors) =>
+      anchors.map((anchor) => (anchor as HTMLAnchorElement).pathname).filter((path) => path.startsWith('/pmoke/')),
+    );
+    for (const link of rendered) links.add(link);
+  }
+
+  for (const link of links) {
+    const response = await page.request.get(link);
+    expect(response.status(), link).toBeLessThan(400);
+  }
+});
+
+test('SEO outputs contain canonical locale mappings and social image', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'desktop-chromium', 'single-browser metadata gate');
+
+  await page.goto('/pmoke/ja/docs/quickstart/');
+  await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+    'href',
+    'https://kerr-group.github.io/pmoke/ja/docs/quickstart/',
+  );
+  for (const locale of ['en', 'ja', 'x-default']) {
+    await expect(page.locator(`link[rel="alternate"][hreflang="${locale}"]`)).toHaveCount(1);
+  }
+  const imageUrl = await page.locator('meta[property="og:image"]').getAttribute('content');
+  expect(imageUrl).toBeTruthy();
+  const image = await page.request.get(new URL(imageUrl!).pathname);
+  expect(image.ok()).toBeTruthy();
+  expect(image.headers()['content-type']).toContain('image/png');
+
+  const sitemap = await page.request.get('/pmoke/sitemap.xml');
+  expect(sitemap.ok()).toBeTruthy();
+  expect(await sitemap.text()).toContain('https://kerr-group.github.io/pmoke/ja/docs/quickstart/');
+  const robots = await page.request.get('/pmoke/robots.txt');
+  expect(robots.ok()).toBeTruthy();
+  expect(await robots.text()).toContain('Sitemap: https://kerr-group.github.io/pmoke/sitemap.xml');
+});


### PR DESCRIPTION
## Summary
- add persistent light/dark theming, locale-preserving navigation, and a refined pmoke/Fumadocs shell
- add canonical/hreflang metadata, sitemap, robots, and a static Open Graph image for the `/pmoke/` project path
- package a GitHub Pages artifact on CI, deploy only from `main`, and verify the deployed site
- expand browser gates across locales, themes, and four viewports with axe, no-JS, reduced-motion, internal-link, and SEO checks

## Local verification
- `cargo fmt --all -- --check`
- `cargo check --locked --workspace --all-targets --all-features`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo test --locked --workspace --lib --bins --tests --examples --all-features` (484 passed)
- Node 22.23.1: `pnpm check` and `pnpm build`
- Node 22.23.1: Playwright (35 passed, 21 conditional skips)
- `pnpm audit --audit-level high`
- `actionlint .github/workflows/docs-site.yml`

## Merge gate
Do not merge until static review is clean and all required GitHub checks have completed successfully.