### PR TITLE
test(docs): remove release search hydration flake

### DIFF
--- a/website/tests/release-browser.spec.ts
+++ b/website/tests/release-browser.spec.ts
@@ -6,8 +6,17 @@ test('release browser renders, searches, and navigates by keyboard', async ({ pa
   await expect(page.getByRole('heading', { level: 1, name: 'Quickstart' })).toBeVisible();
   expect(await hasHorizontalOverflow(page)).toBeFalsy();
 
-  await page.keyboard.press('Control+k');
   const search = page.getByRole('textbox');
+  const fullSearchTrigger = page.locator('[data-search-full]:visible');
+  const searchTrigger = (await fullSearchTrigger.count()) > 0
+    ? fullSearchTrigger.first()
+    : page.locator('[data-search]:visible').first();
+  await searchTrigger.click();
+  await expect(search).toBeVisible();
+  await page.keyboard.press('Escape');
+  await expect(search).toBeHidden();
+
+  await page.keyboard.press('Control+k');
   await expect(search).toBeFocused();
   await search.fill('lock-in filter');
   await expect(page.getByText('Waveform Analyzer', { exact: true }).last()).toBeVisible();


### PR DESCRIPTION
## Summary
- exercise the responsive search trigger before the keyboard shortcut assertion
- distinguish the desktop full search trigger from the mobile icon trigger
- retain the Ctrl+K focus contract while removing the SSR hydration race

## Review evidence
- post-merge M6 run 30745703867 reported 2 flaky first attempts in `release-browser.spec.ts`
- desktop/mobile shortcut gate passed 20 consecutive retry-free repetitions locally
- all Chromium viewport and stable Chrome release-browser tests passed
- ESLint, TypeScript, and `git diff --check` passed

## Local environment
- local browser tests use wrapped Chrome via `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH`; Firefox/WebKit remain authoritative on Ubuntu CI
