### PR TITLE
docs(readme): rebuild project overview and link validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Install Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: "website/.node-version"
+
+      - name: Verify README links
+        run: node website/scripts/verify-readme.mjs
+
       - name: Install Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:

--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -133,6 +133,7 @@ jobs:
           pnpm lint
           pnpm lint:ja
           pnpm lint:content
+          pnpm lint:readme
           pnpm types:check
 
       - name: Build static site

--- a/README.md
+++ b/README.md
@@ -30,12 +30,9 @@ tracks reproducible run artifacts, and executes the numerical analysis chain
 used to recover a Kerr signal from large oscilloscope captures.
 
 ```text
-  INSTRUMENTS        RAW WAVEFORMS         REFERENCE FIT
-       │                   │                     │
-       └──── acquire ──────┴──── calibrate ─────┘
+ACQUIRE ──▶ REFERENCE ──▶ SENSOR
                             │
-                            ▼
-   KERR ANGLE  ◀──  PHASE ROTATION  ◀──  LOCK-IN  ◀──  SENSOR
+KERR ◀── PHASE ◀── LOCK-IN ◀┘
 ```
 
 ## Why pmoke
@@ -69,13 +66,11 @@ python -m pip install -r requirements.txt
 Transport features are explicit so macOS and analysis-only installations do
 not need a system GPIB library:
 
-| Target | Cargo options |
-| --- | --- |
-| Offline analysis | `--no-default-features` |
-| Direct oscilloscope TCP/IP | `--no-default-features --features hw-core` |
-| Prologix Ethernet | `--no-default-features --features hw-prologix-tcp` |
-| Prologix USB serial | `--no-default-features --features hw-prologix-serial` |
-| Direct GPIB | `--features hw-gpib` |
+- **Offline analysis** · `--no-default-features`
+- **Direct oscilloscope TCP/IP** · `--no-default-features --features hw-core`
+- **Prologix Ethernet** · `--no-default-features --features hw-prologix-tcp`
+- **Prologix USB serial** · `--no-default-features --features hw-prologix-serial`
+- **Direct GPIB** · `--features hw-gpib`
 
 See the [feature matrix](https://kerr-group.github.io/pmoke/en/docs/installation/feature-flags/)
 for platform notes and combined builds.
@@ -105,18 +100,14 @@ pmoke --config config.toml --run-dir shot-001 auto
 
 ## Command surface
 
-| Command | Purpose |
-| --- | --- |
-| `pmoke` / `pmoke monitor` | Open the interactive terminal workspace |
-| `pmoke config init\|validate\|explain\|migrate` | Create, inspect, and migrate configuration |
-| `pmoke doctor` | Diagnose config, storage, Python, features, and connected instruments |
-| `pmoke show` | Print normalized configuration and diagnostics |
-| `pmoke analyze` | Run reference, sensor, lock-in, phase, and Kerr stages |
-| `pmoke reference\|sensor\|li\|phase\|kerr` | Run one numerical analysis stage |
-| `pmoke raw verify` | Verify waveform metadata, sizes, and checksums |
-| `pmoke instruments list\|explain\|query` | Inspect drivers or issue one SCPI text query |
-| `pmoke bench scpi-query\|transport` | Benchmark request latency and save reproducible results |
-| `pmoke export csv\|npy` | Export stored data to interchange formats |
+- **Terminal workspace** · `pmoke`, `pmoke monitor`
+- **Configuration** · `pmoke config init|validate|explain|migrate`
+- **Diagnostics** · `pmoke doctor`, `pmoke show`, `pmoke raw verify`
+- **Full analysis** · `pmoke analyze`
+- **Analysis stages** · `pmoke reference|sensor|li|phase|kerr`
+- **Instrument registry and queries** · `pmoke instruments list|explain|query`
+- **Transport benchmarks** · `pmoke bench scpi-query|transport`
+- **Data interchange** · `pmoke export csv|npy`
 
 The generated [CLI reference](https://kerr-group.github.io/pmoke/en/docs/cli/reference/)
 is the source of truth for flags and feature-gated commands.

--- a/README.md
+++ b/README.md
@@ -1,133 +1,166 @@
-<div align="center">
+<h1 align="center">pmoke</h1>
 
-# 💥 pmoke
+<p align="center">
+  <strong>Pulsed-field MOKE, from instrument trigger to Kerr angle.</strong>
+</p>
 
-**High-Performance Pulsed MOKE Measurement & Waveform Demodulation System**
+<p align="center">
+  <code>ACQUIRE</code>&nbsp;&nbsp;·&nbsp;&nbsp;<code>DEMODULATE</code>&nbsp;&nbsp;·&nbsp;&nbsp;<code>ROTATE</code>&nbsp;&nbsp;·&nbsp;&nbsp;<code>ANALYZE</code>
+</p>
 
-[![CI](https://github.com/Kerr-group/pmoke/actions/workflows/ci.yml/badge.svg)](https://github.com/Kerr-group/pmoke/actions/workflows/ci.yml)
-[![Docs Site](https://img.shields.io/badge/docs-online-6366f1?style=flat-square&logo=github-pages&logoColor=white)](https://kerr-group.github.io/pmoke/)
-[![Rust](https://img.shields.io/badge/rust-1.85%2B-orange?style=flat-square&logo=rust)](https://www.rust-lang.org/)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue?style=flat-square)](LICENSE)
+<p align="center">
+  <a href="https://github.com/Kerr-group/pmoke/actions/workflows/ci.yml"><img alt="CI status" src="https://github.com/Kerr-group/pmoke/actions/workflows/ci.yml/badge.svg"></a>
+  <a href="https://kerr-group.github.io/pmoke/en/"><img alt="Documentation" src="https://img.shields.io/badge/docs-live-16a34a?style=flat-square"></a>
+  <a href="https://www.rust-lang.org/"><img alt="Rust 2024" src="https://img.shields.io/badge/Rust-2024-000000?style=flat-square&logo=rust"></a>
+  <a href="LICENSE"><img alt="Apache 2.0 license" src="https://img.shields.io/badge/license-Apache--2.0-2563eb?style=flat-square"></a>
+</p>
 
-[📖 Documentation Site](https://kerr-group.github.io/pmoke/) | [⚡ Quickstart](#-quickstart) | [🎛️ CLI Reference](#%EF%B8%8F-cli-reference) | [✨ Features](#-key-features)
+<p align="center">
+  <a href="https://kerr-group.github.io/pmoke/en/">Documentation</a>
+  · <a href="#quick-start">Quick start</a>
+  · <a href="#command-surface">Commands</a>
+  · <a href="https://kerr-group.github.io/pmoke/ja/">日本語</a>
+</p>
 
 ---
 
-</div>
-
-`pmoke` is a modern, high-precision command-line tool for **pulsed Magneto-Optical Kerr Effect (MOKE)** measurements and automated waveform analysis. Built in Rust and WebAssembly, it seamlessly orchestrates hardware instruments, processes multi-channel oscilloscopes, and executes complete lock-in demodulation chains.
+`pmoke` is a Rust command-line and terminal application for pulsed
+magneto-optical Kerr effect measurements. It connects acquisition hardware,
+tracks reproducible run artifacts, and executes the numerical analysis chain
+used to recover a Kerr signal from large oscilloscope captures.
 
 ```text
-reference ➔ sensor integral ➔ lock-in demodulation ➔ phase rotation ➔ Kerr angle
+  INSTRUMENTS        RAW WAVEFORMS         REFERENCE FIT
+       │                   │                     │
+       └──── acquire ──────┴──── calibrate ─────┘
+                            │
+                            ▼
+   KERR ANGLE  ◀──  PHASE ROTATION  ◀──  LOCK-IN  ◀──  SENSOR
 ```
 
----
+## Why pmoke
 
-## ✨ Key Features
+| Capability | What it provides |
+| --- | --- |
+| Binary acquisition | Rigol DHO5000-series 16-bit WORD captures without a CSV bottleneck |
+| Numerical lock-in | Boxcar, zero-phase FIR/IIR, phase rotation, and Kerr-angle analysis |
+| Instrument transports | Direct TCP/IP, Linux GPIB, Windows USBTMC/VISA, and Prologix TCP/serial |
+| Live terminal UI | One command surface for configuration, analysis, logs, selection, and monitoring |
+| Reproducible runs | Versioned TOML configuration, immutable snapshots, checksums, and isolated run directories |
+| Browser tools | Rust/Wasm configuration validation and interactive waveform analysis in the documentation site |
 
-- ⚡ **High-Speed Binary Waveform Ingestion**: Direct support for Rigol DHO5000-series 16-bit WORD binary captures (`.u16le`), avoiding CSV bottlenecks in large memory acquisitions.
-- 🎛️ **Full Lock-In Demodulation**: Hardware/software lock-in with zero-phase FIR/IIR filtering and boxcar demodulation.
-- 📊 **Interactive Terminal Dashboard**: Real-time activity telemetry with `pmoke monitor` featuring paused-history navigation and calm status metrics.
-- 🌐 **WebAssembly & Web Interactive Tools**: Interactive waveform analysis and live diagnostic tools running directly in the browser via Wasm.
-- 🔧 **Multi-Transport Hardware Control**: Native SCPI controller over TCP/Ethernet, Direct GPIB, and Prologix USB/Serial bridges.
-- 🛡️ **Immutable Shot Provenance**: TOML-based reproducible configuration (`version = 4`) with isolated atomic run directories.
+## Quick start
 
----
+### Install
 
-## ⚡ Quickstart
-
-### 1. Installation
-
-Build and install `pmoke` using Cargo (Rust 1.85+ required):
+Clone the repository, then select only the transports required by the host:
 
 ```bash
-# Hardware-enabled build (Direct TCP / Prologix / GPIB)
-cargo install --path .
+git clone https://github.com/Kerr-group/pmoke.git
+cd pmoke
 
-# Analysis-only build (Lightweight CLI for offline processing)
-cargo install --path . --no-default-features
+# Default: direct GPIB plus shared hardware support
+cargo install --path . --locked
+
+# Plotting and Python-backed analysis
+python -m pip install -r requirements.txt
 ```
 
-Install Python plotting and analysis dependencies:
+Transport features are explicit so macOS and analysis-only installations do
+not need a system GPIB library:
+
+| Target | Cargo options |
+| --- | --- |
+| Offline analysis | `--no-default-features` |
+| Direct oscilloscope TCP/IP | `--no-default-features --features hw-core` |
+| Prologix Ethernet | `--no-default-features --features hw-prologix-tcp` |
+| Prologix USB serial | `--no-default-features --features hw-prologix-serial` |
+| Direct GPIB | `--features hw-gpib` |
+
+See the [feature matrix](https://kerr-group.github.io/pmoke/en/docs/installation/feature-flags/)
+for platform notes and combined builds.
+
+### Run
 
 ```bash
-pip install -r requirements.txt
-```
-
-### 2. Basic Workflow
-
-```bash
-# 1. Validate configuration
-pmoke --config config.toml show
-
-# 2. Check hardware connections & instrument diagnostics
+# Generate, validate, and diagnose a configuration
+pmoke config init --output config.toml
+pmoke --config config.toml config validate
 pmoke --config config.toml doctor
 
-# 3. Automated single-shot pulse, fetch & analysis
-pmoke --config config.toml auto
+# Analyze existing waveforms into an isolated run directory
+pmoke --config config.toml --run-dir shot-001 analyze
 
-# 4. Launch live terminal monitor dashboard
+# Open the terminal workspace; running `pmoke` alone does the same
 pmoke --config config.toml monitor
 ```
 
----
+Hardware-enabled builds add `single`, `trigger`, `autoshot`, `fetch`,
+`screenshot`, `automeasure`, `process`, and `auto`. The complete automated
+measurement and analysis path is:
 
-## 🎛️ CLI Reference
+```bash
+pmoke --config config.toml --run-dir shot-001 auto
+```
 
-| Command | Description |
-| :--- | :--- |
-| `pmoke show` | Validate configuration syntax and hardware bindings |
-| `pmoke doctor` | Preflight check for instruments, Python environment, and storage |
-| `pmoke auto` | Trigger single shot, capture waveforms, and run analysis |
-| `pmoke monitor` | Open the interactive TUI activity dashboard |
-| `pmoke fetch` | Retrieve raw waveforms from oscilloscope |
-| `pmoke analyze` | Re-run lock-in & Kerr angle analysis on existing captures |
-| `pmoke export csv` | Convert verified raw binary `.u16le` waveforms to CSV |
-| `pmoke instruments list` | List supported instrument drivers and protocols |
+## Command surface
 
----
+| Command | Purpose |
+| --- | --- |
+| `pmoke` / `pmoke monitor` | Open the interactive terminal workspace |
+| `pmoke config init\|validate\|explain\|migrate` | Create, inspect, and migrate configuration |
+| `pmoke doctor` | Diagnose config, storage, Python, features, and connected instruments |
+| `pmoke show` | Print normalized configuration and diagnostics |
+| `pmoke analyze` | Run reference, sensor, lock-in, phase, and Kerr stages |
+| `pmoke reference\|sensor\|li\|phase\|kerr` | Run one numerical analysis stage |
+| `pmoke raw verify` | Verify waveform metadata, sizes, and checksums |
+| `pmoke instruments list\|explain\|query` | Inspect drivers or issue one SCPI text query |
+| `pmoke bench scpi-query\|transport` | Benchmark request latency and save reproducible results |
+| `pmoke export csv\|npy` | Export stored data to interchange formats |
 
-## 📁 Repository Structure
+The generated [CLI reference](https://kerr-group.github.io/pmoke/en/docs/cli/reference/)
+is the source of truth for flags and feature-gated commands.
+
+## Workspace
 
 ```text
 pmoke/
+├── src/                         CLI, TUI, workflows, and Python bridge
 ├── crates/
-│   ├── pmoke-core/      # Core numerical analysis & Rust engine
-│   └── pmoke-web-wasm/  # WebAssembly bindings for docs site & browser tools
-├── website/             # Fumadocs static documentation site & interactive tools
-├── scripts/             # Python analysis & benchmark utilities
-└── config.toml          # Example configuration file
+│   ├── instruments/             instrument registry and drivers
+│   ├── gpib-rs/                 direct GPIB transport
+│   ├── prologix-rs/             Prologix TCP and serial transport
+│   ├── pmoke-config-core/       shared configuration model and validation
+│   ├── pmoke-analysis-core/     shared numerical analysis
+│   └── pmoke-web-wasm/          browser bindings for shared Rust cores
+├── website/                     bilingual Fumadocs site and browser tools
+├── scripts/                     benchmark plotting and comparison utilities
+└── xtask/                       generated CLI and configuration references
 ```
 
----
+## Documentation
 
-## 📖 Complete Documentation
+| Guide | English | 日本語 |
+| --- | :---: | :---: |
+| Quick start | [Open](https://kerr-group.github.io/pmoke/en/docs/quickstart/) | [開く](https://kerr-group.github.io/pmoke/ja/docs/quickstart/) |
+| CLI reference | [Open](https://kerr-group.github.io/pmoke/en/docs/cli/reference/) | [開く](https://kerr-group.github.io/pmoke/ja/docs/cli/reference/) |
+| Configuration | [Open](https://kerr-group.github.io/pmoke/en/docs/configuration/reference/) | [開く](https://kerr-group.github.io/pmoke/ja/docs/configuration/reference/) |
+| Waveform analyzer | [Open](https://kerr-group.github.io/pmoke/en/docs/interactive/waveform-analyzer/) | [開く](https://kerr-group.github.io/pmoke/ja/docs/interactive/waveform-analyzer/) |
 
-Visit our official documentation website for comprehensive guides, CLI reference, configuration schema, and interactive waveform tools:
+## Publications
 
-👉 **[https://kerr-group.github.io/pmoke/](https://kerr-group.github.io/pmoke/)**
+If `pmoke` contributes to published work, cite the measurement method relevant
+to the experiment:
 
-- 🚀 [Quickstart Guide](https://kerr-group.github.io/pmoke/docs/quickstart)
-- 💻 [CLI Reference](https://kerr-group.github.io/pmoke/docs/cli/reference)
-- ⚙️ [Configuration Reference](https://kerr-group.github.io/pmoke/docs/configuration/reference)
-- 📊 [Interactive Waveform Analyzer](https://kerr-group.github.io/pmoke/docs/interactive/waveform-analyzer)
+- A. Ikeda, S. Nakamura, S. Yamane, K. Noda, A. Ikeda, and S. Yonezawa,
+  “Magneto-optical Kerr-effect measurements under pulsed magnetic fields over
+  40 T using a compact sample fixture,” *Physical Review Research* **8**,
+  013169 (2026). [doi:10.1103/vy7j-ylb4](https://doi.org/10.1103/vy7j-ylb4)
+- S. Yamane, S. Nakamura, A. Ikeda, K. Noda, A. Ikeda, and S. Yonezawa,
+  “Magneto-optical Kerr effect measurements under bipolar pulsed magnetic
+  fields,” *JJAP Conference Proceedings* **12**, 011011 (2026).
+  [doi:10.56646/jjapcp.12.0_011011](https://doi.org/10.56646/jjapcp.12.0_011011)
 
----
+## License
 
-## 📚 Publications & References
-
-If you use `pmoke` in your scientific research, please consider citing the following publications:
-
-- **Magneto-optical Kerr-effect measurements under pulsed magnetic fields over 40 T using a compact sample fixture**  
-  Atsutoshi Ikeda, Sota Nakamura, Soichiro Yamane, Kosuke Noda, Akihiko Ikeda, and Shingo Yonezawa  
-  *Phys. Rev. Research* (2026). DOI: [10.1103/vy7j-ylb4](https://journals.aps.org/prresearch/abstract/10.1103/vy7j-ylb4)
-
-- **Magneto-optical Kerr effect measurements under bipolar pulsed magnetic fields**  
-  Soichiro Yamane, Sota Nakamura, Atsutoshi Ikeda, Kosuke Noda, Akihiko Ikeda, and Shingo Yonezawa  
-  *JJAP Conf. Proc.* **12**, 011011 (2026). Article: [J-STAGE 12_011011](https://www.jstage.jst.go.jp/article/jjapcp/12/0/12_011011/_article/-char/ja)
-
----
-
-## 📄 License
-
-This project is licensed under the [Apache 2.0 License](LICENSE).
+Licensed under the [Apache License 2.0](LICENSE).

--- a/website/content/docs/en/installation/index.mdx
+++ b/website/content/docs/en/installation/index.mdx
@@ -30,7 +30,7 @@ cargo install --path . --no-default-features
 pmoke --version
 pmoke instruments list
 pmoke config init --output config.toml
-pmoke config validate --config config.toml
+pmoke --config config.toml config validate
 ```
 
 Continue with [feature selection](./feature-flags) for a minimal platform build.

--- a/website/content/docs/en/quickstart.mdx
+++ b/website/content/docs/en/quickstart.mdx
@@ -5,7 +5,7 @@ description: Validate a configuration and run the complete analysis pipeline.
 
 ```bash
 pmoke config init --output config.toml
-pmoke config validate --config config.toml
+pmoke --config config.toml config validate
 pmoke --config config.toml doctor
 pmoke --config config.toml --run-dir shot-001 analyze
 ```

--- a/website/content/docs/ja/installation/index.mdx
+++ b/website/content/docs/ja/installation/index.mdx
@@ -28,7 +28,7 @@ cargo install --path . --no-default-features
 pmoke --version
 pmoke instruments list
 pmoke config init --output config.toml
-pmoke config validate --config config.toml
+pmoke --config config.toml config validate
 ```
 
 platform ごとの最小 build に向けた [feature 選択](./feature-flags)。

--- a/website/content/docs/ja/quickstart.mdx
+++ b/website/content/docs/ja/quickstart.mdx
@@ -5,7 +5,7 @@ description: 設定検証と完全解析パイプラインの実行手順。
 
 ```bash
 pmoke config init --output config.toml
-pmoke config validate --config config.toml
+pmoke --config config.toml config validate
 pmoke --config config.toml doctor
 pmoke --config config.toml --run-dir shot-001 analyze
 ```

--- a/website/package.json
+++ b/website/package.json
@@ -17,6 +17,7 @@
     "lint": "eslint . --max-warnings=0",
     "lint:ja": "node scripts/lint-ja.mjs",
     "lint:content": "node scripts/verify-content.mjs",
+    "lint:readme": "node scripts/verify-readme.mjs",
     "test:export": "node scripts/verify-export.mjs",
     "test:e2e": "playwright test",
     "test:lighthouse": "lhci collect --config=lighthouserc.cjs && node scripts/verify-lighthouse.mjs",
@@ -24,7 +25,7 @@
     "test:ai": "node scripts/verify-ai-resources.mjs",
     "test:search": "node scripts/evaluate-search.mjs",
     "test:signal": "node scripts/verify-signal.mjs",
-    "check": "npm run lint && npm run lint:ja && npm run lint:content && npm run types:check && npm run test:search && npm run test:signal && npm run test:ai && npm run test:export"
+    "check": "npm run lint && npm run lint:ja && npm run lint:content && npm run lint:readme && npm run types:check && npm run test:search && npm run test:signal && npm run test:ai && npm run test:export"
   },
   "dependencies": {
     "@orama/orama": "3.1.18",

--- a/website/scripts/verify-content.mjs
+++ b/website/scripts/verify-content.mjs
@@ -21,6 +21,10 @@ const forbidden = [
     pattern: /\b(?:10(?:\.\d{1,3}){3}|192\.168(?:\.\d{1,3}){2}|172\.(?:1[6-9]|2\d|3[01])(?:\.\d{1,3}){2})\b/u,
   },
   { name: 'unfinished placeholder', pattern: /\b(?:TODO|TBD|coming soon)\b/iu },
+  {
+    name: 'misplaced global --config option',
+    pattern: /\bpmoke\s+config\s+validate\s+--config\b/u,
+  },
 ];
 for (const file of contentFiles) {
   const source = await readFile(file, 'utf8');

--- a/website/scripts/verify-readme.mjs
+++ b/website/scripts/verify-readme.mjs
@@ -1,0 +1,94 @@
+import { access, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const websiteRoot = path.resolve(scriptDirectory, '..');
+const repositoryRoot = path.resolve(websiteRoot, '..');
+const readmePath = path.join(repositoryRoot, 'README.md');
+const readme = await readFile(readmePath, 'utf8');
+const docsOrigin = 'https://kerr-group.github.io';
+const docsPrefix = '/pmoke/';
+const links = new Set();
+const headings = new Set(
+  [...readme.matchAll(/^#{1,6}\s+(.+?)\s*$/gmu)].map((match) => slug(match[1])),
+);
+
+for (const match of readme.matchAll(/!?\[[^\]]*\]\(([^)\s]+)(?:\s+"[^"]*")?\)/gu)) {
+  links.add(match[1]);
+}
+for (const match of readme.matchAll(/\b(?:href|src)="([^"]+)"/gu)) {
+  links.add(match[1]);
+}
+
+for (const target of links) {
+  if (target.startsWith('#')) {
+    verifyFragment(target.slice(1));
+    continue;
+  }
+
+  let url;
+  try {
+    url = new URL(target);
+  } catch {
+    await verifyLocalPath(target);
+    continue;
+  }
+
+  if (url.origin === docsOrigin && url.pathname.startsWith(docsPrefix)) {
+    await verifyDocumentationPath(url);
+  }
+}
+
+console.log(`README verification passed for ${links.size} unique links and images.`);
+
+function verifyFragment(fragment) {
+  if (!headings.has(fragment)) {
+    throw new Error(`README fragment does not match a heading: #${fragment}`);
+  }
+}
+
+async function verifyLocalPath(target) {
+  const clean = target.split('#', 1)[0];
+  if (!clean) return;
+  await access(path.resolve(repositoryRoot, clean)).catch(() => {
+    throw new Error(`README local target does not exist: ${target}`);
+  });
+}
+
+async function verifyDocumentationPath(url) {
+  const relative = url.pathname.slice(docsPrefix.length).replace(/\/$/u, '');
+  if (!relative) return;
+
+  const [locale, docsSegment, ...segments] = relative.split('/');
+  if (!['en', 'ja'].includes(locale)) {
+    throw new Error(`documentation URL must include an en or ja locale: ${url.href}`);
+  }
+  if (!docsSegment) return;
+  if (docsSegment !== 'docs' || segments.length === 0) {
+    throw new Error(`unrecognized documentation URL: ${url.href}`);
+  }
+
+  const contentPath = path.resolve(
+    websiteRoot,
+    'content/docs',
+    locale,
+    ...segments.slice(0, -1),
+    `${segments.at(-1)}.mdx`,
+  );
+  const indexPath = path.resolve(websiteRoot, 'content/docs', locale, ...segments, 'index.mdx');
+  const found = await Promise.any([access(contentPath), access(indexPath)]).then(
+    () => true,
+    () => false,
+  );
+  if (!found) throw new Error(`documentation URL has no matching source page: ${url.href}`);
+}
+
+function slug(heading) {
+  return heading
+    .normalize('NFKD')
+    .toLowerCase()
+    .replace(/[^\p{Letter}\p{Number}\s-]/gu, '')
+    .trim()
+    .replace(/\s+/gu, '-');
+}


### PR DESCRIPTION
## Summary
- rebuild the README around the current CLI, transport features, workspace, and research workflow
- replace broken documentation URLs with verified locale-aware routes
- correct `config validate` examples in English and Japanese docs
- validate README local/docs targets in CI

## Validation
- `pnpm check`
- `node website/scripts/verify-readme.mjs`
- live HTTP checks for all documentation routes
- GitHub Markdown API render inspection
- feature-gated CLI help comparison