### PR TITLE
docs(readme): restore visual icons and correct pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">pmoke</h1>
+<h1 align="center">⚡ pmoke</h1>
 
 <p align="center">
   <strong>Pulsed-field MOKE, from instrument trigger to Kerr angle.</strong>
@@ -16,10 +16,10 @@
 </p>
 
 <p align="center">
-  <a href="https://kerr-group.github.io/pmoke/en/">Documentation</a>
-  · <a href="#quick-start">Quick start</a>
-  · <a href="#command-surface">Commands</a>
-  · <a href="https://kerr-group.github.io/pmoke/ja/">日本語</a>
+  <a href="https://kerr-group.github.io/pmoke/en/">📖 Documentation</a>
+  · <a href="#quick-start">⚡ Quick start</a>
+  · <a href="#command-surface">⌨️ Commands</a>
+  · <a href="https://kerr-group.github.io/pmoke/ja/">🇯🇵 日本語</a>
 </p>
 
 ---
@@ -29,26 +29,32 @@ magneto-optical Kerr effect measurements. It connects acquisition hardware,
 tracks reproducible run artifacts, and executes the numerical analysis chain
 used to recover a Kerr signal from large oscilloscope captures.
 
-```text
-ACQUIRE ──▶ REFERENCE ──▶ SENSOR
-                            │
-KERR ◀── PHASE ◀── LOCK-IN ◀┘
+```mermaid
+flowchart LR
+    RAW["📡 Raw waveforms"] --> REF["🎯 Reference fit"]
+    RAW --> SENSOR["📈 Sensor integration"]
+    REF --> LOCKIN["⚙️ Lock-in"]
+    LOCKIN --> PHASE["🔄 Phase rotation"]
+    PHASE --> KERR["🧲 Kerr angle"]
+    SENSOR --> KERR
 ```
 
-## Why pmoke
+## ✨ Why pmoke
 
 | Capability | What it provides |
 | --- | --- |
-| Binary acquisition | Rigol DHO5000-series 16-bit WORD captures without a CSV bottleneck |
-| Numerical lock-in | Boxcar, zero-phase FIR/IIR, phase rotation, and Kerr-angle analysis |
-| Instrument transports | Direct TCP/IP, Linux GPIB, Windows USBTMC/VISA, and Prologix TCP/serial |
-| Live terminal UI | One command surface for configuration, analysis, logs, selection, and monitoring |
-| Reproducible runs | Versioned TOML configuration, immutable snapshots, checksums, and isolated run directories |
-| Browser tools | Rust/Wasm configuration validation and interactive waveform analysis in the documentation site |
+| 📥 Binary acquisition | Rigol DHO5000-series 16-bit WORD captures without a CSV bottleneck |
+| 〰️ Numerical lock-in | Boxcar, zero-phase FIR/IIR, phase rotation, and Kerr-angle analysis |
+| 🔌 Instrument transports | Direct TCP/IP, Linux GPIB, Windows USBTMC/VISA, and Prologix TCP/serial |
+| 🖥️ Live terminal UI | One command surface for configuration, analysis, logs, selection, and monitoring |
+| 🧾 Reproducible runs | Versioned TOML configuration, immutable snapshots, checksums, and isolated run directories |
+| 🌐 Browser tools | Rust/Wasm configuration validation and interactive waveform analysis in the documentation site |
 
-## Quick start
+<a id="quick-start"></a>
 
-### Install
+## ⚡ Quick start
+
+### 📦 Install
 
 Clone the repository, then select only the transports required by the host:
 
@@ -66,16 +72,16 @@ python -m pip install -r requirements.txt
 Transport features are explicit so macOS and analysis-only installations do
 not need a system GPIB library:
 
-- **Offline analysis** · `--no-default-features`
-- **Direct oscilloscope TCP/IP** · `--no-default-features --features hw-core`
-- **Prologix Ethernet** · `--no-default-features --features hw-prologix-tcp`
-- **Prologix USB serial** · `--no-default-features --features hw-prologix-serial`
-- **Direct GPIB** · `--features hw-gpib`
+- 💻 **Offline analysis** · `--no-default-features`
+- 🌐 **Direct oscilloscope TCP/IP** · `--no-default-features --features hw-core`
+- 🌍 **Prologix Ethernet** · `--no-default-features --features hw-prologix-tcp`
+- 🔗 **Prologix USB serial** · `--no-default-features --features hw-prologix-serial`
+- 🔌 **Direct GPIB** · `--features hw-gpib`
 
 See the [feature matrix](https://kerr-group.github.io/pmoke/en/docs/installation/feature-flags/)
 for platform notes and combined builds.
 
-### Run
+### ▶️ Run
 
 ```bash
 # Generate, validate, and diagnose a configuration
@@ -98,21 +104,23 @@ measurement and analysis path is:
 pmoke --config config.toml --run-dir shot-001 auto
 ```
 
-## Command surface
+<a id="command-surface"></a>
 
-- **Terminal workspace** · `pmoke`, `pmoke monitor`
-- **Configuration** · `pmoke config init|validate|explain|migrate`
-- **Diagnostics** · `pmoke doctor`, `pmoke show`, `pmoke raw verify`
-- **Full analysis** · `pmoke analyze`
-- **Analysis stages** · `pmoke reference|sensor|li|phase|kerr`
-- **Instrument registry and queries** · `pmoke instruments list|explain|query`
-- **Transport benchmarks** · `pmoke bench scpi-query|transport`
-- **Data interchange** · `pmoke export csv|npy`
+## ⌨️ Command surface
+
+- 🖥️ **Terminal workspace** · `pmoke`, `pmoke monitor`
+- ⚙️ **Configuration** · `pmoke config init|validate|explain|migrate`
+- 🩺 **Diagnostics** · `pmoke doctor`, `pmoke show`, `pmoke raw verify`
+- 🚀 **Full analysis** · `pmoke analyze`
+- 🧪 **Analysis stages** · `pmoke reference|sensor|li|phase|kerr`
+- 🔌 **Instrument registry and queries** · `pmoke instruments list|explain|query`
+- ⏱️ **Transport benchmarks** · `pmoke bench scpi-query|transport`
+- 📤 **Data interchange** · `pmoke export csv|npy`
 
 The generated [CLI reference](https://kerr-group.github.io/pmoke/en/docs/cli/reference/)
 is the source of truth for flags and feature-gated commands.
 
-## Workspace
+## 🧱 Workspace
 
 ```text
 pmoke/
@@ -129,7 +137,7 @@ pmoke/
 └── xtask/                       generated CLI and configuration references
 ```
 
-## Documentation
+## 📚 Documentation
 
 | Guide | English | 日本語 |
 | --- | :---: | :---: |
@@ -138,7 +146,7 @@ pmoke/
 | Configuration | [Open](https://kerr-group.github.io/pmoke/en/docs/configuration/reference/) | [開く](https://kerr-group.github.io/pmoke/ja/docs/configuration/reference/) |
 | Waveform analyzer | [Open](https://kerr-group.github.io/pmoke/en/docs/interactive/waveform-analyzer/) | [開く](https://kerr-group.github.io/pmoke/ja/docs/interactive/waveform-analyzer/) |
 
-## Publications
+## 🔬 Publications
 
 If `pmoke` contributes to published work, cite the measurement method relevant
 to the experiment:
@@ -152,6 +160,6 @@ to the experiment:
   fields,” *JJAP Conference Proceedings* **12**, 011011 (2026).
   [doi:10.56646/jjapcp.12.0_011011](https://doi.org/10.56646/jjapcp.12.0_011011)
 
-## License
+## 📄 License
 
 Licensed under the [Apache License 2.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ magneto-optical Kerr effect measurements. It connects acquisition hardware,
 tracks reproducible run artifacts, and executes the numerical analysis chain
 used to recover a Kerr signal from large oscilloscope captures.
 
-![pmoke analysis data flow](docs/assets/readme-pipeline.svg)
+<p align="center">
+  <img src="docs/assets/readme-pipeline.svg" alt="pmoke analysis data flow" width="600">
+</p>
 
 ## ✨ Why pmoke
 

--- a/README.md
+++ b/README.md
@@ -29,15 +29,7 @@ magneto-optical Kerr effect measurements. It connects acquisition hardware,
 tracks reproducible run artifacts, and executes the numerical analysis chain
 used to recover a Kerr signal from large oscilloscope captures.
 
-```mermaid
-flowchart TB
-    RAW["📡 Raw waveforms"] --> REF["🎯 Reference fit"]
-    RAW --> SENSOR["📈 Sensor integration"]
-    REF --> LOCKIN["⚙️ Lock-in"]
-    LOCKIN --> PHASE["🔄 Phase rotation"]
-    PHASE --> KERR["🧲 Kerr angle"]
-    SENSOR --> KERR
-```
+![pmoke analysis data flow](docs/assets/readme-pipeline.svg)
 
 ## ✨ Why pmoke
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">⚡ pmoke</h1>
+<h1 align="center">💥 pmoke</h1>
 
 <p align="center">
   <strong>Pulsed-field MOKE, from instrument trigger to Kerr angle.</strong>
@@ -30,7 +30,7 @@ tracks reproducible run artifacts, and executes the numerical analysis chain
 used to recover a Kerr signal from large oscilloscope captures.
 
 ```mermaid
-flowchart LR
+flowchart TB
     RAW["📡 Raw waveforms"] --> REF["🎯 Reference fit"]
     RAW --> SENSOR["📈 Sensor integration"]
     REF --> LOCKIN["⚙️ Lock-in"]

--- a/docs/assets/readme-pipeline.svg
+++ b/docs/assets/readme-pipeline.svg
@@ -1,0 +1,72 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 625" role="img" aria-labelledby="title description">
+  <title id="title">pmoke analysis data flow</title>
+  <desc id="description">Raw waveforms split into reference and sensor branches. Reference fitting feeds lock-in demodulation and phase rotation. The rotated signal and integrated sensor data combine into the Kerr angle.</desc>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#64748b"/>
+    </marker>
+  </defs>
+  <style>
+    .node { fill: #ffffff; stroke-width: 2; }
+    .raw { fill: #ecfeff; stroke: #0891b2; }
+    .reference { fill: #fff1f2; stroke: #e11d48; }
+    .lockin { fill: #eff6ff; stroke: #2563eb; }
+    .sensor { fill: #fffbeb; stroke: #d97706; }
+    .phase { fill: #f5f3ff; stroke: #7c3aed; }
+    .kerr { fill: #fef2f2; stroke: #dc2626; }
+    .flow { fill: none; stroke: #64748b; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; marker-end: url(#arrow); }
+    .join-flow { fill: none; stroke: #64748b; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
+    .join { fill: #64748b; }
+    .label { fill: #0f172a; font: 600 18px Inter, ui-sans-serif, system-ui, sans-serif; text-anchor: middle; }
+    .detail { fill: #64748b; font: 500 12px Inter, ui-sans-serif, system-ui, sans-serif; letter-spacing: 0.08em; text-anchor: middle; }
+    .reference-detail { font-size: 10px; letter-spacing: 0.02em; }
+    @media (prefers-color-scheme: dark) {
+      .node { fill: #161b22; }
+      .label { fill: #f0f6fc; }
+      .detail { fill: #9da7b3; }
+      .flow, .join-flow { stroke: #8b949e; }
+      .join { fill: #8b949e; }
+      #arrow path { fill: #8b949e; }
+    }
+  </style>
+
+  <path class="flow" d="M300 95 V125 H145 V155"/>
+  <path class="flow" d="M300 95 V125 H455 V275"/>
+  <path class="flow" d="M145 225 V275"/>
+  <path class="flow" d="M145 345 V395"/>
+  <path class="join-flow" d="M145 465 V495 H295"/>
+  <path class="join-flow" d="M455 345 V495 H305"/>
+  <circle class="join" cx="300" cy="495" r="5"/>
+  <path class="flow" d="M300 500 V530"/>
+
+  <g>
+    <rect class="node raw" x="180" y="25" width="240" height="70" rx="8"/>
+    <text class="label" x="300" y="57">📡 Raw waveforms</text>
+    <text class="detail" x="300" y="79">OSCILLOSCOPE INPUT</text>
+  </g>
+  <g>
+    <rect class="node reference" x="35" y="155" width="220" height="70" rx="8"/>
+    <text class="label" x="145" y="187">🎯 Reference fit</text>
+    <text class="detail reference-detail" x="145" y="209">FREQUENCY · AMPLITUDE · PHASE</text>
+  </g>
+  <g>
+    <rect class="node lockin" x="35" y="275" width="220" height="70" rx="8"/>
+    <text class="label" x="145" y="307">⚙️ Lock-in</text>
+    <text class="detail" x="145" y="329">I/Q DEMODULATION</text>
+  </g>
+  <g>
+    <rect class="node sensor" x="345" y="275" width="220" height="70" rx="8"/>
+    <text class="label" x="455" y="307">📈 Sensor integration</text>
+    <text class="detail" x="455" y="329">INTEGRATED FIELD AXIS</text>
+  </g>
+  <g>
+    <rect class="node phase" x="35" y="395" width="220" height="70" rx="8"/>
+    <text class="label" x="145" y="427">🔄 Phase rotation</text>
+    <text class="detail" x="145" y="449">HARMONIC ROTATION</text>
+  </g>
+  <g>
+    <rect class="node kerr" x="180" y="530" width="240" height="70" rx="8"/>
+    <text class="label" x="300" y="562">🧲 Kerr angle</text>
+    <text class="detail" x="300" y="584">CALIBRATED OUTPUT</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- restore purposeful emoji accents across the README
- replace the incorrect linear analysis diagram with the actual branched data flow
- render the pipeline as a responsive GitHub Mermaid graph
- retain stable explicit navigation anchors

## Validation
- `node website/scripts/verify-readme.mjs`
- GitHub Markdown API Mermaid render inspection
- Kerr input dependency comparison against `src/kerr/mod.rs`