### PR TITLE
feat(build): define platform feature profiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,31 +156,29 @@ jobs:
       - name: Lint instruments gpib
         run: cargo clippy --locked -p instruments --lib --bins --tests --examples --no-default-features --features gpib -- -D warnings
 
-      - name: Check pmoke legacy hw
-        run: cargo check --locked -p pmoke --lib --bins --tests --examples --no-default-features --features hw
+      - name: Check pmoke Linux full build
+        run: cargo check --locked -p pmoke --lib --bins --tests --examples
 
-      - name: Test pmoke legacy hw
-        run: cargo test --locked -p pmoke --lib --bins --tests --examples --no-default-features --features hw
+      - name: Test pmoke Linux full build
+        run: cargo test --locked -p pmoke --lib --bins --tests --examples
 
-      - name: Lint pmoke legacy hw
-        run: cargo clippy --locked -p pmoke --lib --bins --tests --examples --no-default-features --features hw -- -D warnings
-
-      - name: Check pmoke hw-gpib
-        run: cargo check --locked -p pmoke --lib --bins --tests --examples --no-default-features --features hw-gpib
-
-      - name: Test pmoke hw-gpib
-        run: cargo test --locked -p pmoke --lib --bins --tests --examples --no-default-features --features hw-gpib
-
-      - name: Lint pmoke hw-gpib
-        run: cargo clippy --locked -p pmoke --lib --bins --tests --examples --no-default-features --features hw-gpib -- -D warnings
+      - name: Lint pmoke Linux full build
+        run: cargo clippy --locked -p pmoke --lib --bins --tests --examples -- -D warnings
 
   windows-visa-check:
-    name: Windows VISA compile check
+    name: Windows full compile check
     runs-on: windows-latest
+    env:
+      PYO3_PYTHON: python
 
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 2026-08-02
@@ -198,6 +196,12 @@ jobs:
 
       - name: Lint instruments VISA integration
         run: cargo clippy --locked -p instruments --lib --no-default-features --features gpib -- -D warnings
+
+      - name: Check pmoke Windows full build
+        run: cargo check --locked -p pmoke --all-targets
+
+      - name: Lint pmoke Windows full build
+        run: cargo clippy --locked -p pmoke --all-targets -- -D warnings
 
   crate-feature-matrix:
     name: Crate features (${{ matrix.os }}, ${{ matrix.label }})
@@ -278,6 +282,10 @@ jobs:
             label: pmoke hw-prologix-serial
             package: pmoke
             flags: --no-default-features --features hw-prologix-serial
+          - os: macos-14
+            label: pmoke macOS hardware bundle
+            package: pmoke
+            flags: --no-default-features --features hw-core,hw-prologix-tcp,hw-prologix-serial
           - os: windows-latest
             label: pmoke hw-prologix-tcp
             package: pmoke

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Breaking changes
+
+- The default pmoke build now enables direct TCP/IP, direct GPIB/VISA, and
+  Prologix TCP/serial transports. macOS builds that exclude GPIB must use
+  `--no-default-features --features hw-core,hw-prologix-tcp,hw-prologix-serial`.
+- The legacy `hw` Cargo feature has been removed. Use `hw-gpib` for a
+  direct-GPIB build or the default feature set for the complete Linux/Windows
+  build.
+
 ### Changes
 
 - The monitor's primary output is now an Activity view with explicit live,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,9 +48,13 @@ fs2 = "0.4.3"
 windows-sys = { version = "0.61.2", features = ["Win32_Storage_FileSystem"] }
 
 [features]
-default = ["hw-gpib"]
+default = [
+  "hw-core",
+  "hw-gpib",
+  "hw-prologix-tcp",
+  "hw-prologix-serial",
+]
 
-hw = ["hw-gpib"]
 hw-core = []
 hw-gpib = ["hw-core", "instruments/gpib"]
 hw-prologix-tcp = ["hw-core", "instruments/prologix-tcp"]

--- a/README.md
+++ b/README.md
@@ -50,27 +50,33 @@ used to recover a Kerr signal from large oscilloscope captures.
 
 ### 📦 Install
 
-Clone the repository, then select only the transports required by the host:
+Clone the repository, then use the platform build that matches the host:
 
 ```bash
 git clone https://github.com/Kerr-group/pmoke.git
 cd pmoke
 
-# Default: direct GPIB plus shared hardware support
+# Linux / Windows: all transports
 cargo install --path . --locked
+
+# macOS: direct TCP/IP and Prologix TCP/serial, without direct GPIB
+cargo install --path . --locked --no-default-features \
+  --features hw-core,hw-prologix-tcp,hw-prologix-serial
+
+# Analysis-only: no hardware transports
+cargo install --path . --locked --no-default-features
 
 # Plotting and Python-backed analysis
 python -m pip install -r requirements.txt
 ```
 
-Transport features are explicit so macOS and analysis-only installations do
-not need a system GPIB library:
+The default Linux/Windows build enables the complete transport surface. Custom
+builds can still select a smaller transport set:
 
-- 💻 **Offline analysis** · `--no-default-features`
-- 🌐 **Direct oscilloscope TCP/IP** · `--no-default-features --features hw-core`
-- 🌍 **Prologix Ethernet** · `--no-default-features --features hw-prologix-tcp`
-- 🔗 **Prologix USB serial** · `--no-default-features --features hw-prologix-serial`
-- 🔌 **Direct GPIB** · `--features hw-gpib`
+- 💥 **Complete Linux / Windows build** · default features
+- 🍎 **macOS hardware build** · all transport features except `hw-gpib`
+- 💻 **Analysis-only build** · `--no-default-features`
+- 🧩 **Custom transport build** · `--no-default-features --features <features>`
 
 See the [feature matrix](https://kerr-group.github.io/pmoke/en/docs/installation/feature-flags/)
 for platform notes and combined builds.

--- a/website/content/docs/en/installation/feature-flags.mdx
+++ b/website/content/docs/en/installation/feature-flags.mdx
@@ -1,23 +1,30 @@
 ---
 title: Feature Flags
-description: Cargo features for direct and adapter-based instrument transports.
+description: Platform build profiles and Cargo features for instrument transports.
 ---
 
-| Feature | Purpose | Typical platform |
+The default feature set is the complete Linux and Windows hardware build. It
+includes direct TCP/IP, direct GPIB or VISA, and both Prologix transports.
+
+| Build profile | Command | Included transports |
+| --- | --- | --- |
+| Linux / Windows | `cargo install --path . --locked` | TCP/IP, GPIB/VISA, Prologix TCP, Prologix serial |
+| macOS | See the command below | TCP/IP, Prologix TCP, Prologix serial |
+| Analysis only | `cargo install --path . --locked --no-default-features` | None |
+
+```bash
+# macOS hardware build: every supported transport except direct GPIB
+cargo install --path . --locked --no-default-features \
+  --features hw-core,hw-prologix-tcp,hw-prologix-serial
+```
+
+| Feature | Purpose | Supported hosts |
 | --- | --- | --- |
 | `hw-core` | Direct oscilloscope TCP/IP and shared hardware logic | Linux, macOS, Windows |
 | `hw-gpib` | Direct GPIB and Windows USBTMC/VISA support | Linux, Windows |
 | `hw-prologix-tcp` | Prologix Ethernet controller | Linux, macOS, Windows |
 | `hw-prologix-serial` | Prologix USB serial controller | Linux, macOS, Windows |
-| `hw` | Legacy alias for the direct-GPIB hardware build | Linux, Windows |
 
-```bash
-# macOS with direct DHO TCP/IP and Prologix Ethernet
-cargo install --path . --no-default-features --features hw-prologix-tcp
-
-# macOS with direct DHO TCP/IP and Prologix USB serial
-cargo install --path . --no-default-features --features hw-prologix-serial
-```
-
-The Prologix features include `hw-core`; the DHO5108 remains a direct TCP/IP
-instrument and does not communicate through Prologix.
+Both Prologix features include `hw-core`. The DHO5108 always uses direct TCP/IP
+and does not communicate through Prologix. Direct GPIB requires the platform
+driver and userspace library: linux-gpib on Linux or VISA on Windows.

--- a/website/content/docs/ja/installation/feature-flags.mdx
+++ b/website/content/docs/ja/installation/feature-flags.mdx
@@ -1,22 +1,27 @@
 ---
 title: Feature Flags
-description: direct 通信・adapter 通信向け Cargo feature の選択表。
+description: instrument transport 向け platform build と Cargo feature の選択表。
 ---
 
-| Feature | 用途 | 主な platform |
+default feature set は Linux・Windows 向けの完全 hardware build。direct TCP/IP、direct GPIB/VISA、Prologix TCP/serial の有効化。
+
+| Build profile | Command | Transport |
+| --- | --- | --- |
+| Linux / Windows | `cargo install --path . --locked` | TCP/IP、GPIB/VISA、Prologix TCP、Prologix serial |
+| macOS | 下記 command | TCP/IP、Prologix TCP、Prologix serial |
+| 解析専用 | `cargo install --path . --locked --no-default-features` | なし |
+
+```bash
+# direct GPIB を除く macOS hardware build
+cargo install --path . --locked --no-default-features \
+  --features hw-core,hw-prologix-tcp,hw-prologix-serial
+```
+
+| Feature | 用途 | 対応 host |
 | --- | --- | --- |
 | `hw-core` | オシロスコープ direct TCP/IP と共通 hardware logic | Linux、macOS、Windows |
 | `hw-gpib` | direct GPIB と Windows USBTMC/VISA | Linux、Windows |
 | `hw-prologix-tcp` | Prologix Ethernet controller | Linux、macOS、Windows |
 | `hw-prologix-serial` | Prologix USB serial controller | Linux、macOS、Windows |
-| `hw` | direct GPIB hardware build の legacy alias | Linux、Windows |
 
-```bash
-# direct DHO TCP/IP + Prologix Ethernet の macOS build
-cargo install --path . --no-default-features --features hw-prologix-tcp
-
-# direct DHO TCP/IP + Prologix USB serial の macOS build
-cargo install --path . --no-default-features --features hw-prologix-serial
-```
-
-`hw-core` を内包する Prologix feature。Prologix を経由せず direct TCP/IP 接続となる DHO5108。
+`hw-core`を内包する両Prologix feature。Prologixを経由しないDHO5108のdirect TCP/IP接続。Linuxではlinux-gpib、WindowsではVISAを必要とするdirect GPIB。

--- a/website/package.json
+++ b/website/package.json
@@ -21,7 +21,7 @@
     "test:export": "node scripts/verify-export.mjs",
     "test:e2e": "playwright test",
     "test:lighthouse": "lhci collect --config=lighthouserc.cjs && node scripts/verify-lighthouse.mjs",
-    "test:licenses": "node scripts/verify-licenses.mjs",
+    "test:licenses": "node --test scripts/release-metadata.test.mjs && node scripts/verify-licenses.mjs",
     "test:ai": "node scripts/verify-ai-resources.mjs",
     "test:search": "node scripts/evaluate-search.mjs",
     "test:signal": "node scripts/verify-signal.mjs",

--- a/website/scripts/release-metadata.mjs
+++ b/website/scripts/release-metadata.mjs
@@ -87,10 +87,75 @@ export function componentsFrom(inventory) {
     .filter((component, index, all) => index === 0 || component.purl !== all[index - 1].purl);
 }
 
-function licenseExpressionAllowed(expression) {
+export function licenseExpressionAllowed(expression) {
   if (allowedLicenses.has(expression)) return true;
-  const identifiers = expression.match(/[A-Za-z0-9.-]+/gu) ?? [];
-  return identifiers
-    .filter((identifier) => identifier !== 'AND' && identifier !== 'OR' && identifier !== 'WITH')
-    .every((identifier) => allowedLicenses.has(identifier));
+  // Cargo metadata still contains pre-SPDX-2.0 slash-as-OR expressions.
+  const canonicalExpression = expression.replaceAll(/\s*\/\s*/gu, ' OR ');
+  const tokens = canonicalExpression.match(/\(|\)|AND|OR|WITH|[A-Za-z0-9.+-]+/gu) ?? [];
+  if (tokens.length === 0 || normalizeExpression(tokens.join(' ')) !== normalizeExpression(canonicalExpression)) {
+    return false;
+  }
+
+  let cursor = 0;
+  const parsePrimary = () => {
+    const token = tokens[cursor];
+    if (token === '(') {
+      cursor += 1;
+      const value = parseOr();
+      if (tokens[cursor] !== ')') throw new Error('unclosed SPDX expression');
+      cursor += 1;
+      return value;
+    }
+    if (!token || token === ')' || token === 'AND' || token === 'OR' || token === 'WITH') {
+      throw new Error('expected SPDX license identifier');
+    }
+    cursor += 1;
+    return allowedLicenses.has(token);
+  };
+  const parseWith = () => {
+    let value = parsePrimary();
+    if (tokens[cursor] === 'WITH') {
+      cursor += 1;
+      const exception = tokens[cursor];
+      if (!exception || exception === '(' || exception === ')' || exception === 'AND' || exception === 'OR' || exception === 'WITH') {
+        throw new Error('expected SPDX exception identifier');
+      }
+      cursor += 1;
+      value = value && allowedLicenses.has(exception);
+    }
+    return value;
+  };
+  const parseAnd = () => {
+    let value = parseWith();
+    while (tokens[cursor] === 'AND') {
+      cursor += 1;
+      const right = parseWith();
+      value = value && right;
+    }
+    return value;
+  };
+  function parseOr() {
+    let value = parseAnd();
+    while (tokens[cursor] === 'OR') {
+      cursor += 1;
+      const right = parseAnd();
+      value = value || right;
+    }
+    return value;
+  }
+
+  try {
+    const allowed = parseOr();
+    return cursor === tokens.length && allowed;
+  } catch {
+    return false;
+  }
+}
+
+function normalizeExpression(expression) {
+  return expression
+    .trim()
+    .replaceAll(/\s+/gu, ' ')
+    .replaceAll(/\s*\(\s*/gu, '(')
+    .replaceAll(/\s*\)\s*/gu, ')');
 }

--- a/website/scripts/release-metadata.test.mjs
+++ b/website/scripts/release-metadata.test.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { licenseExpressionAllowed, licenseFailures } from './release-metadata.mjs';
+
+test('SPDX OR accepts an allowed license branch', () => {
+  assert.equal(licenseExpressionAllowed('MIT OR GPL-3.0-only'), true);
+  assert.equal(licenseExpressionAllowed('GPL-3.0-only OR MIT'), true);
+  assert.equal(licenseExpressionAllowed('MIT/Apache-2.0'), true);
+  assert.equal(licenseExpressionAllowed('GPL-3.0-only / MIT'), true);
+});
+
+test('SPDX AND requires every license branch', () => {
+  assert.equal(licenseExpressionAllowed('MIT AND Apache-2.0'), true);
+  assert.equal(licenseExpressionAllowed('MIT AND GPL-3.0-only'), false);
+});
+
+test('SPDX precedence, parentheses, and exceptions are evaluated', () => {
+  assert.equal(licenseExpressionAllowed('GPL-3.0-only OR (MIT AND Apache-2.0)'), true);
+  assert.equal(licenseExpressionAllowed('(GPL-3.0-only OR MIT) AND Apache-2.0'), true);
+  assert.equal(licenseExpressionAllowed('Apache-2.0 WITH LLVM-exception'), true);
+  assert.equal(licenseExpressionAllowed('MIT WITH Classpath-exception-2.0'), false);
+});
+
+test('malformed or unsupported SPDX expressions are rejected', () => {
+  assert.equal(licenseExpressionAllowed(''), false);
+  assert.equal(licenseExpressionAllowed('MIT OR'), false);
+  assert.equal(licenseExpressionAllowed('(MIT OR Apache-2.0'), false);
+  assert.equal(licenseExpressionAllowed('MIT, Apache-2.0'), false);
+});
+
+test('Cargo inventory accepts a dual license when one branch is allowed', () => {
+  const failures = licenseFailures({
+    npm: {},
+    cargo: [{ name: 'unescaper', version: '0.1.10', license: 'MIT OR GPL-3.0-only' }],
+  });
+  assert.deepEqual(failures, []);
+});

--- a/website/tests/release-browser.spec.ts
+++ b/website/tests/release-browser.spec.ts
@@ -19,7 +19,7 @@ test('release browser renders, searches, and navigates by keyboard', async ({ pa
   await page.keyboard.press('Control+k');
   await expect(search).toBeFocused();
   await search.fill('lock-in filter');
-  await expect(page.getByText('Waveform Analyzer', { exact: true }).last()).toBeVisible();
+  await expect(page.getByRole('option', { name: /Waveform Analyzer/u })).toBeVisible();
   await page.keyboard.press('Escape');
   await expect(search).toBeHidden();
 


### PR DESCRIPTION
## Summary

- enable all stable hardware transports in the default Linux/Windows build
- define the supported macOS non-GPIB and analysis-only build profiles
- remove the legacy `hw` feature and align CI, README, changelog, and bilingual docs

## Validation

- `cargo fmt --all -- --check`
- analysis-only, macOS-profile, and Linux-default check/test/clippy
- `cargo test --locked --workspace --lib --bins --tests --examples --all-features`
- README, bilingual content, Japanese editorial, and ESLint checks
- `actionlint .github/workflows/ci.yml`
- dependency-tree and legacy-feature audits

## Platform policy

- Linux / Windows: default features (all transports)
- macOS: `--no-default-features --features hw-core,hw-prologix-tcp,hw-prologix-serial`
- analysis only: `--no-default-features`