### PR TITLE
ci: accelerate quality pipelines and repair release drafts

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,32 +2,45 @@ name-template: 'v$RESOLVED_VERSION 🌈'
 tag-template: 'v$RESOLVED_VERSION'
 
 categories:
+  - type: pre-exclude
+    when:
+      label: 'skip-changelog'
+
   - title: '⚠️ Breaking Changes'
-    labels:
-      - 'breaking'
+    semver-increment: minor
+    when:
+      label: 'breaking'
   - title: '🚀 Features'
-    labels:
-      - 'feature'
+    semver-increment: minor
+    when:
+      label: 'feature'
   - title: '💪 Enhancement'
-    labels:
-      - 'enhancement'
+    semver-increment: minor
+    when:
+      label: 'enhancement'
   - title: '🐛 Bug Fixes'
-    labels:
-      - 'fix'
-      - 'bugfix'
-      - 'bug'
+    when:
+      label: 'bug'
   - title: '🧰 Maintenance'
-    label: 'chore'
+    when:
+      label: 'chore'
   - title: '🔧 Refactoring'
-    label: 'refactor'
+    when:
+      label: 'refactor'
   - title: '📖 Documentation'
-    label: 'documentation'
+    when:
+      label: 'documentation'
   - title: '⛓️ Dependency update'
-    label: 'dependencies'
+    when:
+      label: 'dependencies'
+  - title: '🧩 Other Changes'
 
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+
+sort-by: merged_at
+sort-direction: descending
 
 version-resolver:
   major:
@@ -47,54 +60,51 @@ template: |
   $CHANGES
 
 autolabeler:
-  - label: minor
-    branch:
-      - '/^release[/]v0[.][0-9]+([/-].*)?$/'
   - label: breaking
     branch:
       - '/^release[/]v0[.][0-9]+([/-].*)?$/'
+    title:
+      - '/^[a-z]+(?:\([^)]+\))?!:/i'
+    body:
+      - '/BREAKING[ -]CHANGE:/i'
   - label: feature
     branch:
       - '/^feat(ure)?[/-].+/'
+    title:
+      - '/^feat(?:\([^)]+\))?!?:/i'
   - label: bug
     branch:
       - '/^fix[/-].+/'
+    title:
+      - '/^fix(?:\([^)]+\))?!?:/i'
   - label: chore
     branch:
       - '/^chore[/-].+/'
+      - '/^ci[/-].+/'
+    title:
+      - '/^(?:build|chore|ci|perf|test)(?:\([^)]+\))?!?:/i'
   - label: refactor
     branch:
-      - '/(refactor|refactoring)[/-].+/'
+      - '/^(?:refactor|refactoring)[/-].+/'
+    title:
+      - '/^refactor(?:\([^)]+\))?!?:/i'
   - label: documentation
     branch:
-      - '/doc(umentation)[/-].+/'
+      - '/^docs?(?:umentation)?[/-].+/'
+    title:
+      - '/^docs?(?:\([^)]+\))?!?:/i'
     files:
-      - '*.md'
-  - label: documentation
-    branch:
-      - '/docs(umentation)[/-].+/'
-    files:
-      - '*.md'
+      - 'README.md'
+      - 'docs/**'
+      - 'website/content/**'
+      - 'website/docs/**'
   - label: enhancement
     branch:
-      - '/(enhancement|improve)[/-].+/'
-
-  - label: nextjs
-    files:
-      - 'src/**/*'
-      - 'package.json'
-      - 'yarn.lock'
-      - 'next*'
-      - 'tsconfig.json'
-      - '.eslintrc.json'
-  - label: wasm
-    files:
-      - 'wasm/**/*'
-  - label: docker
-    files:
-      - 'docker/**/*'
-      - 'Dockerfile'
-      - '.dockerignore'
-  - label: github
-    files:
-      - '.github/**/*'
+      - '/^(?:enhancement|improve)[/-].+/'
+    title:
+      - '/^(?:enhance|improve|optimize|refine)(?:\([^)]+\))?!?:/i'
+  - label: dependencies
+    branch:
+      - '/^(?:dependabot|renovate)[/-].+/'
+    title:
+      - '/^(?:build|chore)\(deps\)!?:/i'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -6,6 +6,21 @@ categories:
     when:
       label: 'skip-changelog'
 
+  - type: version-resolver
+    semver-increment: major
+    when:
+      label: 'major'
+  - type: version-resolver
+    semver-increment: minor
+    when:
+      label: 'minor'
+  - type: version-resolver
+    semver-increment: patch
+    when:
+      label: 'patch'
+  - type: version-resolver
+    semver-increment: patch
+
   - title: '⚠️ Breaking Changes'
     semver-increment: minor
     when:
@@ -41,18 +56,6 @@ change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add
 
 sort-by: merged_at
 sort-direction: descending
-
-version-resolver:
-  major:
-    labels:
-      - 'major'
-  minor:
-    labels:
-      - 'minor'
-  patch:
-    labels:
-      - 'patch'
-  default: patch
 
 template: |
   ## Changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,70 +263,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
-            label: prologix-rs no-default
-            package: prologix-rs
-            flags: --no-default-features
-          - os: ubuntu-latest
-            label: prologix-rs tcp
-            package: prologix-rs
-            flags: --no-default-features --features tcp
-          - os: ubuntu-latest
-            label: prologix-rs serial
-            package: prologix-rs
-            flags: --no-default-features --features serial
-          - os: macos-14
-            label: prologix-rs tcp
-            package: prologix-rs
-            flags: --no-default-features --features tcp
-          - os: macos-14
-            label: prologix-rs serial
-            package: prologix-rs
-            flags: --no-default-features --features serial
+          # Keep the longest observed profiles first within each hosted-runner pool.
           - os: windows-latest
-            label: prologix-rs tcp
-            package: prologix-rs
-            flags: --no-default-features --features tcp
-          - os: windows-latest
-            label: prologix-rs serial
-            package: prologix-rs
-            flags: --no-default-features --features serial
-          - os: ubuntu-latest
-            label: instruments no-default
-            package: instruments
-            flags: --no-default-features
-          - os: ubuntu-latest
-            label: instruments prologix-tcp
-            package: instruments
-            flags: --no-default-features --features prologix-tcp
-          - os: ubuntu-latest
-            label: instruments prologix-serial
-            package: instruments
-            flags: --no-default-features --features prologix-serial
-          - os: macos-14
-            label: instruments prologix-tcp
-            package: instruments
-            flags: --no-default-features --features prologix-tcp
-          - os: macos-14
-            label: instruments prologix-serial
-            package: instruments
-            flags: --no-default-features --features prologix-serial
-          - os: windows-latest
-            label: instruments prologix-tcp
-            package: instruments
-            flags: --no-default-features --features prologix-tcp
-          - os: windows-latest
-            label: instruments prologix-serial
-            package: instruments
-            flags: --no-default-features --features prologix-serial
-          - os: ubuntu-latest
-            label: pmoke hw-prologix-tcp
-            package: pmoke
-            flags: --no-default-features --features hw-prologix-tcp
-          - os: ubuntu-latest
             label: pmoke hw-prologix-serial
             package: pmoke
             flags: --no-default-features --features hw-prologix-serial
+          - os: windows-latest
+            label: pmoke hw-prologix-tcp
+            package: pmoke
+            flags: --no-default-features --features hw-prologix-tcp
           - os: macos-14
             label: pmoke hw-prologix-tcp
             package: pmoke
@@ -339,14 +284,70 @@ jobs:
             label: pmoke macOS hardware bundle
             package: pmoke
             flags: --no-default-features --features hw-core,hw-prologix-tcp,hw-prologix-serial
-          - os: windows-latest
+          - os: ubuntu-latest
+            label: pmoke hw-prologix-serial
+            package: pmoke
+            flags: --no-default-features --features hw-prologix-serial
+          - os: ubuntu-latest
             label: pmoke hw-prologix-tcp
             package: pmoke
             flags: --no-default-features --features hw-prologix-tcp
           - os: windows-latest
-            label: pmoke hw-prologix-serial
-            package: pmoke
-            flags: --no-default-features --features hw-prologix-serial
+            label: instruments prologix-serial
+            package: instruments
+            flags: --no-default-features --features prologix-serial
+          - os: windows-latest
+            label: instruments prologix-tcp
+            package: instruments
+            flags: --no-default-features --features prologix-tcp
+          - os: windows-latest
+            label: prologix-rs serial
+            package: prologix-rs
+            flags: --no-default-features --features serial
+          - os: windows-latest
+            label: prologix-rs tcp
+            package: prologix-rs
+            flags: --no-default-features --features tcp
+          - os: macos-14
+            label: instruments prologix-serial
+            package: instruments
+            flags: --no-default-features --features prologix-serial
+          - os: macos-14
+            label: instruments prologix-tcp
+            package: instruments
+            flags: --no-default-features --features prologix-tcp
+          - os: macos-14
+            label: prologix-rs tcp
+            package: prologix-rs
+            flags: --no-default-features --features tcp
+          - os: macos-14
+            label: prologix-rs serial
+            package: prologix-rs
+            flags: --no-default-features --features serial
+          - os: ubuntu-latest
+            label: prologix-rs tcp
+            package: prologix-rs
+            flags: --no-default-features --features tcp
+          - os: ubuntu-latest
+            label: prologix-rs no-default
+            package: prologix-rs
+            flags: --no-default-features
+          - os: ubuntu-latest
+            label: instruments no-default
+            package: instruments
+            flags: --no-default-features
+          - os: ubuntu-latest
+            label: instruments prologix-serial
+            package: instruments
+            flags: --no-default-features --features prologix-serial
+          - os: ubuntu-latest
+            label: prologix-rs serial
+            package: prologix-rs
+            flags: --no-default-features --features serial
+          - os: ubuntu-latest
+            label: instruments prologix-tcp
+            package: instruments
+            flags: --no-default-features --features prologix-tcp
     env:
       PYO3_PYTHON: python
       PYTHONDONTWRITEBYTECODE: "1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,21 +257,33 @@ jobs:
         run: cargo clippy --locked -p pmoke --all-targets -- -D warnings
 
   crate-feature-matrix:
-    name: Crate feature suite (${{ matrix.os }})
+    name: Crate feature suite (${{ matrix.os }}, ${{ matrix.suite }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - os: windows-latest
+            suite: pmoke hw-prologix-serial
+            cache-key: pmoke-serial
             profiles: |
               pmoke|hw-prologix-serial|--no-default-features --features hw-prologix-serial
+          - os: windows-latest
+            suite: pmoke hw-prologix-tcp
+            cache-key: pmoke-tcp
+            profiles: |
               pmoke|hw-prologix-tcp|--no-default-features --features hw-prologix-tcp
+          - os: windows-latest
+            suite: transport crates
+            cache-key: transport-crates
+            profiles: |
               instruments|prologix-serial|--no-default-features --features prologix-serial
               instruments|prologix-tcp|--no-default-features --features prologix-tcp
               prologix-rs|serial|--no-default-features --features serial
               prologix-rs|tcp|--no-default-features --features tcp
           - os: macos-14
+            suite: all profiles
+            cache-key: all-profiles
             profiles: |
               pmoke|hw-prologix-tcp|--no-default-features --features hw-prologix-tcp
               pmoke|hw-prologix-serial|--no-default-features --features hw-prologix-serial
@@ -281,6 +293,8 @@ jobs:
               prologix-rs|tcp|--no-default-features --features tcp
               prologix-rs|serial|--no-default-features --features serial
           - os: ubuntu-latest
+            suite: all profiles
+            cache-key: all-profiles
             profiles: |
               pmoke|hw-prologix-serial|--no-default-features --features hw-prologix-serial
               pmoke|hw-prologix-tcp|--no-default-features --features hw-prologix-tcp
@@ -318,7 +332,7 @@ jobs:
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
-          shared-key: feature-suite-${{ matrix.os }}
+          shared-key: feature-suite-${{ matrix.os }}-${{ matrix.cache-key }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Check, test, and lint feature profiles

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,8 +226,6 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
-          cache: pip
-          cache-dependency-path: requirements.txt
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 2026-08-02

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,97 +257,39 @@ jobs:
         run: cargo clippy --locked -p pmoke --all-targets -- -D warnings
 
   crate-feature-matrix:
-    name: Crate features (${{ matrix.os }}, ${{ matrix.label }})
+    name: Crate feature suite (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          # Keep the longest observed profiles first within each hosted-runner pool.
           - os: windows-latest
-            label: pmoke hw-prologix-serial
-            package: pmoke
-            flags: --no-default-features --features hw-prologix-serial
-          - os: windows-latest
-            label: pmoke hw-prologix-tcp
-            package: pmoke
-            flags: --no-default-features --features hw-prologix-tcp
+            profiles: |
+              pmoke|hw-prologix-serial|--no-default-features --features hw-prologix-serial
+              pmoke|hw-prologix-tcp|--no-default-features --features hw-prologix-tcp
+              instruments|prologix-serial|--no-default-features --features prologix-serial
+              instruments|prologix-tcp|--no-default-features --features prologix-tcp
+              prologix-rs|serial|--no-default-features --features serial
+              prologix-rs|tcp|--no-default-features --features tcp
           - os: macos-14
-            label: pmoke hw-prologix-tcp
-            package: pmoke
-            flags: --no-default-features --features hw-prologix-tcp
-          - os: macos-14
-            label: pmoke hw-prologix-serial
-            package: pmoke
-            flags: --no-default-features --features hw-prologix-serial
-          - os: macos-14
-            label: pmoke macOS hardware bundle
-            package: pmoke
-            flags: --no-default-features --features hw-core,hw-prologix-tcp,hw-prologix-serial
+            profiles: |
+              pmoke|hw-prologix-tcp|--no-default-features --features hw-prologix-tcp
+              pmoke|hw-prologix-serial|--no-default-features --features hw-prologix-serial
+              pmoke|macOS hardware bundle|--no-default-features --features hw-core,hw-prologix-tcp,hw-prologix-serial
+              instruments|prologix-serial|--no-default-features --features prologix-serial
+              instruments|prologix-tcp|--no-default-features --features prologix-tcp
+              prologix-rs|tcp|--no-default-features --features tcp
+              prologix-rs|serial|--no-default-features --features serial
           - os: ubuntu-latest
-            label: pmoke hw-prologix-serial
-            package: pmoke
-            flags: --no-default-features --features hw-prologix-serial
-          - os: ubuntu-latest
-            label: pmoke hw-prologix-tcp
-            package: pmoke
-            flags: --no-default-features --features hw-prologix-tcp
-          - os: windows-latest
-            label: instruments prologix-serial
-            package: instruments
-            flags: --no-default-features --features prologix-serial
-          - os: windows-latest
-            label: instruments prologix-tcp
-            package: instruments
-            flags: --no-default-features --features prologix-tcp
-          - os: windows-latest
-            label: prologix-rs serial
-            package: prologix-rs
-            flags: --no-default-features --features serial
-          - os: windows-latest
-            label: prologix-rs tcp
-            package: prologix-rs
-            flags: --no-default-features --features tcp
-          - os: macos-14
-            label: instruments prologix-serial
-            package: instruments
-            flags: --no-default-features --features prologix-serial
-          - os: macos-14
-            label: instruments prologix-tcp
-            package: instruments
-            flags: --no-default-features --features prologix-tcp
-          - os: macos-14
-            label: prologix-rs tcp
-            package: prologix-rs
-            flags: --no-default-features --features tcp
-          - os: macos-14
-            label: prologix-rs serial
-            package: prologix-rs
-            flags: --no-default-features --features serial
-          - os: ubuntu-latest
-            label: prologix-rs tcp
-            package: prologix-rs
-            flags: --no-default-features --features tcp
-          - os: ubuntu-latest
-            label: prologix-rs no-default
-            package: prologix-rs
-            flags: --no-default-features
-          - os: ubuntu-latest
-            label: instruments no-default
-            package: instruments
-            flags: --no-default-features
-          - os: ubuntu-latest
-            label: instruments prologix-serial
-            package: instruments
-            flags: --no-default-features --features prologix-serial
-          - os: ubuntu-latest
-            label: prologix-rs serial
-            package: prologix-rs
-            flags: --no-default-features --features serial
-          - os: ubuntu-latest
-            label: instruments prologix-tcp
-            package: instruments
-            flags: --no-default-features --features prologix-tcp
+            profiles: |
+              pmoke|hw-prologix-serial|--no-default-features --features hw-prologix-serial
+              pmoke|hw-prologix-tcp|--no-default-features --features hw-prologix-tcp
+              prologix-rs|tcp|--no-default-features --features tcp
+              prologix-rs|no-default|--no-default-features
+              instruments|no-default|--no-default-features
+              instruments|prologix-serial|--no-default-features --features prologix-serial
+              prologix-rs|serial|--no-default-features --features serial
+              instruments|prologix-tcp|--no-default-features --features prologix-tcp
     env:
       PYO3_PYTHON: python
       PYTHONDONTWRITEBYTECODE: "1"
@@ -376,18 +318,38 @@ jobs:
       - name: Restore Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
-          shared-key: features-${{ matrix.os }}-${{ matrix.package }}
-          key: ${{ matrix.label }}
+          shared-key: feature-suite-${{ matrix.os }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
-      - name: Check ${{ matrix.label }}
-        run: cargo check --locked -p ${{ matrix.package }} --lib --bins --tests --examples ${{ matrix.flags }}
-
-      - name: Test ${{ matrix.label }}
-        run: cargo test --locked -p ${{ matrix.package }} --lib --bins --tests --examples ${{ matrix.flags }}
-
-      - name: Lint ${{ matrix.label }}
-        run: cargo clippy --locked -p ${{ matrix.package }} --lib --bins --tests --examples ${{ matrix.flags }} -- -D warnings
+      - name: Check, test, and lint feature profiles
+        shell: bash
+        env:
+          FEATURE_PROFILES: ${{ matrix.profiles }}
+        run: |
+          status=0
+          while IFS='|' read -r package label flags; do
+            test -n "${package}" || continue
+            profile_status=0
+            read -r -a cargo_flags <<< "${flags}"
+            echo "::group::${package} ${label}"
+            if ! cargo check --locked -p "${package}" --lib --bins --tests --examples "${cargo_flags[@]}"; then
+              profile_status=1
+            fi
+            if ! cargo test --locked -p "${package}" --lib --bins --tests --examples "${cargo_flags[@]}"; then
+              profile_status=1
+            fi
+            if ! cargo clippy --locked -p "${package}" --lib --bins --tests --examples "${cargo_flags[@]}" -- -D warnings; then
+              profile_status=1
+            fi
+            echo "::endgroup::"
+            if (( profile_status == 0 )); then
+              echo "PASS  ${package} ${label}" >> "${GITHUB_STEP_SUMMARY}"
+            else
+              echo "FAIL  ${package} ${label}" >> "${GITHUB_STEP_SUMMARY}"
+              status=1
+            fi
+          done <<< "${FEATURE_PROFILES}"
+          exit "${status}"
 
   analysis-portability:
     name: Analysis-only (${{ matrix.os }}, Python ${{ matrix.python }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 
@@ -9,8 +10,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   test:
@@ -35,6 +36,8 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements.txt
 
       - name: Install Python dependencies
         run: |
@@ -69,6 +72,12 @@ jobs:
         with:
           components: rustfmt, clippy
 
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+        with:
+          shared-key: workspace-all-features
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
       - name: Check formatting
         run: cargo fmt --all -- --check
 
@@ -84,11 +93,41 @@ jobs:
       - name: Test
         run: cargo test --locked --workspace --lib --bins --tests --examples --all-features
 
-      - name: Performance smoke test
-        run: cargo bench --locked --no-default-features --bench performance -- --smoke
-
       - name: Lint
         run: cargo clippy --locked --workspace --all-targets --all-features -- -D warnings
+
+  performance-smoke:
+    name: Performance smoke test
+    runs-on: ubuntu-latest
+    env:
+      PYO3_PYTHON: python
+      PYTHONDONTWRITEBYTECODE: "1"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install Python dependencies
+        run: python -m pip install -r requirements.txt
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 2026-08-02
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+        with:
+          shared-key: performance-smoke
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Run deterministic smoke benchmark
+        run: cargo bench --locked --no-default-features --bench performance -- --smoke
 
   hardware-feature-slices:
     name: Hardware feature slices
@@ -104,6 +143,8 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements.txt
 
       - name: Install Python dependencies
         run: |
@@ -137,6 +178,12 @@ jobs:
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 2026-08-02
         with:
           components: clippy
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+        with:
+          shared-key: linux-full-hardware
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Check gpib-rs
         run: cargo check --locked -p gpib-rs --lib --bins --tests --examples
@@ -179,11 +226,19 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements.txt
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 2026-08-02
         with:
           components: clippy
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+        with:
+          shared-key: windows-full
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Check gpib-rs VISA bindings
         run: cargo check --locked -p gpib-rs --lib
@@ -306,6 +361,8 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements.txt
 
       - name: Install Python dependencies
         run: |
@@ -316,6 +373,13 @@ jobs:
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 2026-08-02
         with:
           components: clippy
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+        with:
+          shared-key: features-${{ matrix.os }}-${{ matrix.package }}
+          key: ${{ matrix.label }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Check ${{ matrix.label }}
         run: cargo check --locked -p ${{ matrix.package }} --lib --bins --tests --examples ${{ matrix.flags }}
@@ -353,6 +417,8 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python }}
+          cache: pip
+          cache-dependency-path: requirements.txt
 
       - name: Install Python dependencies
         run: |
@@ -363,6 +429,12 @@ jobs:
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 2026-08-02
         with:
           components: clippy
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+        with:
+          shared-key: analysis-${{ matrix.os }}-${{ matrix.python }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Check analysis-only targets
         run: cargo check --locked -p pmoke --all-targets --no-default-features

--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -2,6 +2,7 @@ name: Documentation site
 
 on:
   push:
+    branches: [main]
     paths:
       - "website/**"
       - "crates/**"
@@ -33,8 +34,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: docs-site-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  group: docs-site-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   security:
@@ -63,13 +64,17 @@ jobs:
           arguments: --all-features
           command-arguments: advisories licenses sources
 
+      - name: Enable pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          package_json_file: website/package.json
+
       - name: Install Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: "website/.node-version"
-
-      - name: Enable pnpm
-        run: corepack enable pnpm
+          cache: pnpm
+          cache-dependency-path: website/pnpm-lock.yaml
 
       - name: Install dependencies
         working-directory: website
@@ -82,8 +87,7 @@ jobs:
           pnpm test:licenses
 
   build:
-    name: Production static export and quality gates
-    needs: security
+    name: Build static documentation artifact
     runs-on: ubuntu-latest
     timeout-minutes: 35
     outputs:
@@ -102,6 +106,12 @@ jobs:
         with:
           tool: wasm-pack@0.15.0
 
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+        with:
+          shared-key: docs-wasm
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
       - name: Validate shared config and analysis cores
         run: |
           cargo test --locked -p pmoke-config-core -p pmoke-analysis-core -p pmoke-web-wasm
@@ -115,13 +125,17 @@ jobs:
           cargo xtask docs-export
           git diff --exit-code -- website/generated website/public/config.schema.json website/content/docs/en/cli website/content/docs/ja/cli website/content/docs/en/configuration/reference.mdx website/content/docs/ja/configuration/reference.mdx
 
+      - name: Enable pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          package_json_file: website/package.json
+
       - name: Install Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: "website/.node-version"
-
-      - name: Enable pnpm
-        run: corepack enable pnpm
+          cache: pnpm
+          cache-dependency-path: website/pnpm-lock.yaml
 
       - name: Install dependencies
         working-directory: website
@@ -147,17 +161,14 @@ jobs:
           pnpm test:ai
           pnpm test:export
 
-      - name: Install release browsers
-        working-directory: website
-        run: pnpm exec playwright install --with-deps chromium firefox webkit chrome
-
-      - name: Run browser, accessibility, and visual gates
-        working-directory: website
-        run: pnpm test:e2e
-
-      - name: Run Lighthouse release gate
-        working-directory: website
-        run: pnpm test:lighthouse
+      - name: Upload static test artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pmoke-docs-static-${{ github.sha }}
+          path: website/out
+          if-no-files-found: error
+          include-hidden-files: true
+          retention-days: 1
 
       - name: Package GitHub Pages preview artifact
         id: pages-artifact
@@ -167,15 +178,102 @@ jobs:
           retention-days: 30
           include-hidden-files: true
 
-      - name: Upload visual evidence
+  browser-quality:
+    name: Browser, accessibility, and visual gates
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Enable pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          package_json_file: website/package.json
+
+      - name: Install Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: "website/.node-version"
+          cache: pnpm
+          cache-dependency-path: website/pnpm-lock.yaml
+
+      - name: Install dependencies
+        working-directory: website
+        run: pnpm install --frozen-lockfile
+
+      - name: Download static test artifact
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v8.0.1
+        with:
+          name: pmoke-docs-static-${{ github.sha }}
+          path: website/out
+
+      - name: Install release browsers
+        working-directory: website
+        run: pnpm exec playwright install --with-deps chromium firefox webkit chrome
+
+      - name: Run browser, accessibility, and visual gates
+        working-directory: website
+        run: pnpm test:e2e
+
+      - name: Upload browser evidence
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: pmoke-docs-visuals-${{ github.sha }}
+          name: pmoke-docs-browser-${{ github.sha }}
           path: |
             website/test-results
             website/playwright-report
-            website/.lighthouseci
+          if-no-files-found: warn
+          include-hidden-files: true
+          retention-days: 30
+
+  lighthouse-quality:
+    name: Lighthouse release gate
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Enable pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          package_json_file: website/package.json
+
+      - name: Install Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: "website/.node-version"
+          cache: pnpm
+          cache-dependency-path: website/pnpm-lock.yaml
+
+      - name: Install dependencies
+        working-directory: website
+        run: pnpm install --frozen-lockfile
+
+      - name: Download static test artifact
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v8.0.1
+        with:
+          name: pmoke-docs-static-${{ github.sha }}
+          path: website/out
+
+      - name: Install release browser
+        working-directory: website
+        run: pnpm exec playwright install --with-deps chrome
+
+      - name: Run Lighthouse release gate
+        working-directory: website
+        run: pnpm test:lighthouse
+
+      - name: Upload Lighthouse evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pmoke-docs-lighthouse-${{ github.sha }}
+          path: website/.lighthouseci
           if-no-files-found: warn
           include-hidden-files: true
           retention-days: 30
@@ -185,7 +283,7 @@ jobs:
     if: >-
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       (github.event_name == 'workflow_dispatch' && inputs.deploy)
-    needs: build
+    needs: [security, build, browser-quality, lighthouse-quality]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,34 +3,54 @@ name: Release Drafter
 on:
   push:
     branches: [main]
+  pull_request:
+    types: [opened, reopened, synchronize]
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+  workflow_dispatch:
 
+permissions:
+  contents: read
 
-# on:
-#   push:
-#     # branches to consider in the event; optional, defaults to all
-#     branches:
-#       - main
-#     # pull_request event is required only for autolabeler
-#     pull_request:
-#       # Only following types are handled by the action, but one can default to all as well
-#       types: [opened, reopened, synchronize]
-#     # pull_request_target event is required for autolabeler to support PRs from forks
-#     pull_request_target:
-#       types: [opened, reopened, synchronize]
+concurrency:
+  group: release-drafter-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
+
 jobs:
-  update_release_draft:
+  validate-draft:
+    name: Validate release draft
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
-      # (Optional) GitHub Enterprise requires GHE_HOST variable set
-      #- name: Set GHE_HOST
-      #  run: |
-      #    echo "GHE_HOST=${GITHUB_SERVER_URL##https:\/\/}" >> $GITHUB_ENV
+      - name: Render draft without writes
+        uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7.7.0
+        with:
+          config-name: release-drafter.yml
+          dry-run: true
 
-      # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7.7.0
-        # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
-        # with:
-        #   config-name: my-config.yml
-        #   disable-autolabeler: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  auto-label:
+    name: Auto-label pull request
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Apply release labels
+        uses: release-drafter/release-drafter/autolabeler@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7.7.0
+
+  update_release_draft:
+    name: Update release draft
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - name: Render categorized draft
+        uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7.7.0
+        with:
+          config-name: release-drafter.yml


### PR DESCRIPTION
## Summary

- eliminate duplicate branch-push and pull-request workflow runs
- cache Rust, Python, and pnpm dependencies without allowing PRs to overwrite trusted caches
- run performance, security, browser, and Lighthouse quality gates in parallel while preserving every existing check
- restore categorized Release Drafter output with dedicated read-only validation and fork-safe auto-labeling

## Quality preserved

- Rust formatting, tests, clippy, feature matrix, hardware slices, portability, and deterministic performance smoke remain required
- docs lint, type checks, generated references, search, AI resources, static export, browser, accessibility, visual, Lighthouse, dependency policy, and secret scanning remain required
- Pages deployment now waits for all four documentation quality jobs

## Local validation

- `actionlint .github/workflows/*.yml`
- Release Drafter v7 JSON schema validation
- `pnpm check`
- `cargo bench --locked --no-default-features --bench performance -- --smoke`
- `git diff --check`
