### PR TITLE
feat(website): build AI and machine resource hub

### DIFF
--- a/website/app/global.css
+++ b/website/app/global.css
@@ -451,6 +451,312 @@ html:not(.dark) .capability-grid p { color: #52615f; }
   backdrop-filter: blur(14px);
 }
 
+.ai-hub {
+  margin: 2rem 0 2.5rem;
+  overflow: hidden;
+  border-block: 1px solid var(--color-fd-border);
+  background: color-mix(in srgb, var(--color-fd-card) 60%, transparent);
+  font-family: var(--font-sans);
+  letter-spacing: 0;
+}
+
+.ai-hub button,
+.ai-hub a {
+  -webkit-tap-highlight-color: transparent;
+}
+
+.ai-hub__commandbar {
+  min-height: 76px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid var(--color-fd-border);
+}
+
+.ai-hub__identity {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.ai-hub__mark {
+  width: 2.25rem;
+  height: 2.25rem;
+  display: grid;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, var(--cyan) 42%, var(--color-fd-border));
+  background: color-mix(in srgb, var(--cyan) 9%, transparent);
+  color: var(--cyan);
+}
+
+.ai-hub__mark svg { width: 1.1rem; height: 1.1rem; }
+.ai-hub__identity span,
+.ai-hub__bootstrap-title span {
+  display: block;
+  color: var(--cyan);
+  font: 700 0.625rem/1.2 var(--font-mono);
+  text-transform: uppercase;
+}
+.ai-hub__identity h2 {
+  margin: 0.2rem 0 0;
+  font-size: 1rem;
+  line-height: 1.25;
+}
+
+.ai-hub__status {
+  min-height: 1.8rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex: 0 0 auto;
+  padding: 0.3rem 0.55rem;
+  border: 1px solid var(--color-fd-border);
+  color: var(--color-fd-muted-foreground);
+  font: 700 0.625rem/1 var(--font-mono);
+}
+.ai-hub__status svg { width: 0.8rem; height: 0.8rem; }
+.ai-hub__status[data-state='ready'] {
+  border-color: color-mix(in srgb, var(--green) 42%, var(--color-fd-border));
+  color: var(--green);
+}
+.ai-hub__status[data-state='error'] {
+  border-color: color-mix(in srgb, var(--amber) 45%, var(--color-fd-border));
+  color: var(--amber);
+}
+.ai-hub__status[data-state='loading'] svg { animation: ai-hub-spin 1s linear infinite; }
+
+@keyframes ai-hub-spin { to { transform: rotate(360deg); } }
+
+.ai-hub__metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin: 0;
+  border-bottom: 1px solid var(--color-fd-border);
+}
+.ai-hub__metrics div {
+  min-width: 0;
+  padding: 0.75rem 1rem;
+  border-right: 1px solid var(--color-fd-border);
+}
+.ai-hub__metrics div:last-child { border-right: 0; }
+.ai-hub__metrics dt {
+  color: var(--color-fd-muted-foreground);
+  font: 650 0.625rem/1.2 var(--font-mono);
+  text-transform: uppercase;
+}
+.ai-hub__metrics dd {
+  margin: 0.3rem 0 0;
+  overflow: hidden;
+  color: var(--color-fd-foreground);
+  font: 700 0.9rem/1.2 var(--font-mono);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ai-hub__workspace {
+  display: grid;
+  grid-template-columns: 9.5rem minmax(0, 1fr);
+  min-height: 18rem;
+  border-bottom: 1px solid var(--color-fd-border);
+}
+
+.ai-hub__modebar {
+  display: flex;
+  flex-direction: column;
+  padding: 0.75rem;
+  border-right: 1px solid var(--color-fd-border);
+}
+.ai-hub__modebar button {
+  width: 100%;
+  min-height: 2.4rem;
+  padding: 0.45rem 0.65rem;
+  border: 0;
+  border-left: 2px solid transparent;
+  background: transparent;
+  color: var(--color-fd-muted-foreground);
+  font-size: 0.75rem;
+  font-weight: 650;
+  text-align: left;
+  cursor: pointer;
+}
+.ai-hub__modebar button:hover { color: var(--color-fd-foreground); }
+.ai-hub__modebar button[aria-pressed='true'] {
+  border-left-color: var(--magenta);
+  background: color-mix(in srgb, var(--magenta) 8%, transparent);
+  color: var(--color-fd-foreground);
+}
+
+.ai-hub__resources { min-width: 0; }
+.ai-resource {
+  min-height: 8.75rem;
+  display: grid;
+  grid-template-columns: 2rem minmax(0, 1fr) auto;
+  gap: 0.75rem;
+  align-items: start;
+  margin: 0;
+  padding: 1rem;
+  border-bottom: 1px solid var(--color-fd-border);
+}
+.ai-resource:last-child { border-bottom: 0; }
+.ai-resource__icon {
+  width: 2rem;
+  height: 2rem;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--color-fd-border);
+  color: var(--magenta);
+}
+.ai-resource__icon svg { width: 0.95rem; height: 0.95rem; }
+.ai-resource__body { min-width: 0; }
+.ai-resource__heading {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  flex-wrap: wrap;
+}
+.ai-resource__heading h3 {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.3;
+}
+.ai-resource__heading span {
+  padding: 0.18rem 0.4rem;
+  border: 1px solid var(--color-fd-border);
+  color: var(--color-fd-muted-foreground);
+  font: 650 0.575rem/1 var(--font-mono);
+  text-transform: uppercase;
+}
+.ai-resource__body p {
+  margin: 0.4rem 0 0.55rem;
+  color: var(--color-fd-muted-foreground);
+  font-size: 0.75rem;
+  line-height: 1.55;
+}
+.ai-resource__body code {
+  display: block;
+  overflow-wrap: anywhere;
+  color: var(--cyan);
+  font-size: 0.675rem;
+}
+.ai-resource__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.ai-resource__actions button,
+.ai-resource__actions a {
+  width: 2rem;
+  height: 2rem;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--color-fd-border);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--color-fd-muted-foreground);
+  cursor: pointer;
+}
+.ai-resource__actions button:hover,
+.ai-resource__actions a:hover {
+  border-color: var(--cyan);
+  color: var(--cyan);
+}
+.ai-resource__actions svg { width: 0.85rem; height: 0.85rem; }
+
+.ai-hub__bootstrap {
+  display: grid;
+  grid-template-columns: 9.5rem minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: center;
+  padding: 1rem;
+  border-bottom: 1px solid var(--color-fd-border);
+  background: color-mix(in srgb, var(--cyan) 4%, transparent);
+}
+.ai-hub__bootstrap-title strong {
+  display: block;
+  margin-top: 0.3rem;
+  font-size: 0.75rem;
+}
+.ai-hub__bootstrap p {
+  margin: 0;
+  color: var(--color-fd-muted-foreground);
+  font: 0.675rem/1.65 var(--font-mono);
+}
+.ai-hub__bootstrap button {
+  min-height: 2rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.6rem;
+  border: 1px solid var(--cyan);
+  border-radius: 4px;
+  background: var(--cyan);
+  color: #071314;
+  font-size: 0.7rem;
+  font-weight: 750;
+  cursor: pointer;
+}
+.ai-hub__bootstrap button svg { width: 0.8rem; height: 0.8rem; }
+
+.ai-hub__trust {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  padding: 0.7rem 1rem;
+  color: var(--color-fd-muted-foreground);
+}
+.ai-hub__trust span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font: 0.625rem/1.2 var(--font-mono);
+}
+.ai-hub__trust svg { width: 0.75rem; height: 0.75rem; color: var(--green); }
+
+@media (max-width: 720px) {
+  .ai-hub { margin-inline: -0.35rem; }
+  .ai-hub__commandbar { align-items: flex-start; flex-direction: column; }
+  .ai-hub__metrics { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .ai-hub__metrics div:nth-child(2) { border-right: 0; }
+  .ai-hub__metrics div:nth-child(-n + 2) { border-bottom: 1px solid var(--color-fd-border); }
+  .ai-hub__workspace { grid-template-columns: 1fr; }
+  .ai-hub__modebar {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    padding: 0;
+    border-right: 0;
+    border-bottom: 1px solid var(--color-fd-border);
+  }
+  .ai-hub__modebar button {
+    min-width: 0;
+    border-left: 0;
+    border-bottom: 2px solid transparent;
+    text-align: center;
+  }
+  .ai-hub__modebar button[aria-pressed='true'] {
+    border-left-color: transparent;
+    border-bottom-color: var(--magenta);
+  }
+  .ai-resource {
+    grid-template-columns: 2rem minmax(0, 1fr);
+    min-height: 0;
+  }
+  .ai-resource__actions { grid-column: 2; }
+  .ai-hub__bootstrap { grid-template-columns: 1fr; }
+  .ai-hub__bootstrap button { justify-self: start; }
+  .ai-hub__trust { align-items: flex-start; flex-direction: column; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ai-hub__status[data-state='loading'] svg { animation: none; }
+}
+
 .config-validator {
   margin: 2rem 0;
   overflow: hidden;

--- a/website/app/llms.txt/route.ts
+++ b/website/app/llms.txt/route.ts
@@ -1,5 +1,6 @@
-import { getSortedPages } from '@/lib/source';
-import { basePath, siteDescription, siteOrigin } from '@/lib/shared';
+import { machineResources } from '@/lib/machine-resources';
+import { getPageMarkdownUrl, getSortedPages } from '@/lib/source';
+import { absoluteUrl, siteDescription, siteOrigin } from '@/lib/shared';
 import { versionMetadata } from '@/lib/version';
 
 export const revalidate = false;
@@ -8,18 +9,20 @@ export function GET() {
   const sections = ['en', 'ja'].map((locale) => {
     const title = locale === 'ja' ? '日本語' : 'English';
     const pages = getSortedPages(locale).map((page) => {
-      const url = new URL(`${basePath}${page.url}/`, siteOrigin);
+      const url = new URL(getPageMarkdownUrl(page).url, siteOrigin);
       return `- [${page.data.title}](${url}): ${page.data.description ?? ''}`;
     });
     return `## ${title}\n\n${pages.join('\n')}`;
   });
-  const resources = [
-    `- [English full context](${new URL(`${basePath}/llms-en.txt`, siteOrigin)})`,
-    `- [Japanese full context](${new URL(`${basePath}/llms-ja.txt`, siteOrigin)})`,
-    `- [Bilingual full context](${new URL(`${basePath}/llms-full.txt`, siteOrigin)})`,
-    `- [Machine manifest](${new URL(`${basePath}/ai-index.json`, siteOrigin)})`,
-  ].join('\n');
-  const body = `# pmoke\n\n> ${siteDescription}\n\n- pmoke: ${versionMetadata.pmoke_version}\n- config schema: ${versionMetadata.schema_version}\n- source commit: ${versionMetadata.source_commit}\n- canonical root: ${new URL(`${basePath}/`, siteOrigin)}\n- search privacy: browser-local; no query upload or telemetry\n- authority: native pmoke runtime for config semantics and hardware behavior\n\n## Agent resources\n\n${resources}\n\n## Retrieval policy\n\n1. Select the matching locale and smallest relevant page.\n2. Prefer generated JSON for exact command and configuration fields.\n3. Preserve units, field paths, versions, and source links.\n4. Confirm semantic configuration with pmoke config validate.\n5. Never infer laboratory addresses or credentials.\n\n${sections.join('\n\n')}\n`;
+  const contracts = machineResources
+    .filter((resource) => resource.group === 'contract' || resource.id === 'manifest')
+    .map((resource) => `- [${resource.id}](${absoluteUrl(resource.path)}): ${resource.mediaType}`)
+    .join('\n');
+  const optional = machineResources
+    .filter((resource) => resource.group === 'context')
+    .map((resource) => `- [${resource.id}](${absoluteUrl(resource.path)}): ${resource.locale} full context`)
+    .join('\n');
+  const body = `# pmoke\n\n> ${siteDescription}\n\npmoke ${versionMetadata.pmoke_version}; config schema ${versionMetadata.schema_version}; source commit ${versionMetadata.source_commit}. Native pmoke runtime is authoritative for configuration semantics and hardware behavior. Search and browser tools are local-only with no query upload or telemetry. Select the matching locale and smallest relevant page, prefer generated JSON for exact fields, preserve units and source links, confirm configs with pmoke config validate, and never infer laboratory addresses or credentials.\n\n## Machine contracts\n\n${contracts}\n\n${sections.join('\n\n')}\n\n## Optional\n\n${optional}\n`;
   return new Response(body, {
     headers: { 'Content-Type': 'text/plain; charset=utf-8' },
   });

--- a/website/components/ai-resource-hub.tsx
+++ b/website/components/ai-resource-hub.tsx
@@ -1,0 +1,263 @@
+'use client';
+
+import {
+  Bot,
+  Check,
+  Copy,
+  ExternalLink,
+  FileCode2,
+  Files,
+  Globe2,
+  LoaderCircle,
+  Network,
+  ShieldCheck,
+} from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { machineResources, type MachineResourceGroup } from '@/lib/machine-resources';
+import { basePath, siteUrl } from '@/lib/shared';
+
+type Locale = 'en' | 'ja';
+type Manifest = {
+  schema: number;
+  product: string;
+  pmoke_version: string;
+  config_schema_version: number;
+  source_commit: string;
+  pages: unknown[];
+  resources: unknown[];
+};
+
+const copy = {
+  en: {
+    aria: 'AI and machine resource console',
+    kicker: 'MACHINE INTERFACE',
+    title: 'Agent resource console',
+    loading: 'VERIFYING',
+    ready: 'MANIFEST ONLINE',
+    error: 'STATIC LINKS ONLY',
+    metrics: ['Documents', 'Endpoints', 'Config schema', 'Source'],
+    modes: { discovery: 'Discovery', context: 'Context', contract: 'Contracts' },
+    modeLabel: 'Resource type',
+    scope: { en: 'English', ja: 'Japanese', bilingual: 'Bilingual', neutral: 'Language neutral' },
+    open: 'Open resource',
+    copyUrl: 'Copy endpoint URL',
+    copiedUrl: 'Endpoint URL copied',
+    bootstrap: 'AGENT BOOTSTRAP',
+    bootstrapTitle: 'Smallest-context first',
+    bootstrapCopy: 'Copy bootstrap',
+    copiedBootstrap: 'Agent bootstrap copied',
+    copyFailed: 'Clipboard unavailable',
+    trust: ['Same-origin assets', 'No query upload', 'Runtime validation authority'],
+    resources: {
+      'llms-index': ['llms.txt', 'Concise map for selecting the smallest relevant source.'],
+      manifest: ['Machine manifest', 'Versioned page inventory with canonical URLs and SHA-256 digests.'],
+      'english-context': ['English context', 'Complete processed English documentation.'],
+      'japanese-context': ['Japanese context', 'Complete processed Japanese documentation.'],
+      'full-context': ['Bilingual context', 'Complete English and Japanese documentation in one feed.'],
+      'cli-contract': ['CLI contract', 'Generated command, argument, and option tree.'],
+      'config-contract': ['Config contract', 'Generated field registry with types and defaults.'],
+      'config-schema': ['JSON Schema', 'Editor-facing structural schema for canonical config v4.'],
+    },
+    prompt: `Read ${siteUrl}/llms.txt first. Select the smallest relevant locale-specific Markdown source. Prefer generated JSON contracts for exact CLI and config fields. Preserve versions, field paths, units, and canonical URLs. Validate configuration semantics with pmoke config validate; do not infer hardware state, credentials, or laboratory addresses.`,
+  },
+  ja: {
+    aria: 'AI・機械向けリソースコンソール',
+    kicker: 'MACHINE INTERFACE',
+    title: 'エージェントリソースコンソール',
+    loading: '検証中',
+    ready: 'MANIFEST ONLINE',
+    error: '静的リンクのみ',
+    metrics: ['文書', 'エンドポイント', '設定スキーマ', 'ソース'],
+    modes: { discovery: '探索', context: 'コンテキスト', contract: '契約' },
+    modeLabel: 'リソース種別',
+    scope: { en: '英語', ja: '日本語', bilingual: '日英', neutral: '言語非依存' },
+    open: 'リソース表示',
+    copyUrl: 'エンドポイントURLのコピー',
+    copiedUrl: 'エンドポイントURLのコピー完了',
+    bootstrap: 'AGENT BOOTSTRAP',
+    bootstrapTitle: '最小コンテキスト優先',
+    bootstrapCopy: 'ブートストラップのコピー',
+    copiedBootstrap: 'エージェントブートストラップのコピー完了',
+    copyFailed: 'クリップボード利用不可',
+    trust: ['同一オリジン資産', 'クエリ送信なし', '実行時検証の優先'],
+    resources: {
+      'llms-index': ['llms.txt', '最小の関連ソース選択に用いる簡潔な案内。'],
+      manifest: ['機械向けマニフェスト', 'canonical URLとSHA-256 digestを持つversioned page台帳。'],
+      'english-context': ['英語コンテキスト', '処理済み英語documentationの全文。'],
+      'japanese-context': ['日本語コンテキスト', '処理済み日本語documentationの全文。'],
+      'full-context': ['日英コンテキスト', '英語・日本語documentationの統合feed。'],
+      'cli-contract': ['CLI契約', '生成済みcommand・argument・option tree。'],
+      'config-contract': ['設定契約', '型・default値を持つ生成済みfield registry。'],
+      'config-schema': ['JSON Schema', 'canonical config v4向けeditor用構造schema。'],
+    },
+    prompt: `最初に ${siteUrl}/llms.txt を参照。localeに対応する最小のMarkdown sourceを選択。正確なCLI・config fieldには生成JSON契約を優先。version、field path、unit、canonical URLを保持。config semanticsはpmoke config validateで検証。hardware state、credential、実験室addressの推測禁止。`,
+  },
+} as const;
+
+const groupIcons = {
+  discovery: Network,
+  context: Files,
+  contract: FileCode2,
+} as const;
+
+export function AIResourceHub({ locale }: { locale: Locale }) {
+  const text = copy[locale];
+  const [mode, setMode] = useState<MachineResourceGroup>('discovery');
+  const [manifest, setManifest] = useState<Manifest | null>(null);
+  const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
+  const [notice, setNotice] = useState('');
+  const noticeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    fetch(`${basePath}/ai-index.json`, { signal: controller.signal })
+      .then(async (response) => {
+        if (!response.ok) throw new Error(`manifest request failed with ${response.status}`);
+        return response.json() as Promise<Manifest>;
+      })
+      .then((value) => {
+        if (
+          value.schema !== 1
+          || value.product !== 'pmoke'
+          || typeof value.pmoke_version !== 'string'
+          || !Number.isInteger(value.config_schema_version)
+          || typeof value.source_commit !== 'string'
+          || value.source_commit.length < 7
+          || !Array.isArray(value.pages)
+          || value.pages.length === 0
+          || !Array.isArray(value.resources)
+          || value.resources.length !== machineResources.length
+        ) {
+          throw new Error('invalid manifest');
+        }
+        setManifest(value);
+        setStatus('ready');
+      })
+      .catch((error: unknown) => {
+        if (!(error instanceof DOMException && error.name === 'AbortError')) setStatus('error');
+      });
+    return () => controller.abort();
+  }, []);
+
+  useEffect(() => () => {
+    if (noticeTimer.current) clearTimeout(noticeTimer.current);
+  }, []);
+
+  const visibleResources = useMemo(
+    () => machineResources.filter((resource) => resource.group === mode),
+    [mode],
+  );
+  const SourceIcon = groupIcons[mode];
+  const metrics = [
+    manifest?.pages.length ?? '--',
+    manifest?.resources.length ?? machineResources.length,
+    manifest?.config_schema_version ?? '--',
+    manifest?.source_commit.slice(0, 7) ?? '--',
+  ];
+
+  const announce = (message: string) => {
+    setNotice(message);
+    if (noticeTimer.current) clearTimeout(noticeTimer.current);
+    noticeTimer.current = setTimeout(() => setNotice(''), 2_000);
+  };
+
+  const copyText = async (value: string, success: string) => {
+    try {
+      await navigator.clipboard.writeText(value);
+      announce(success);
+    } catch {
+      announce(text.copyFailed);
+    }
+  };
+
+  return (
+    <section className="ai-hub" aria-label={text.aria} data-manifest={status}>
+      <header className="ai-hub__commandbar">
+        <div className="ai-hub__identity">
+          <span className="ai-hub__mark"><Bot aria-hidden="true" /></span>
+          <div>
+            <span>{text.kicker}</span>
+            <h2>{text.title}</h2>
+          </div>
+        </div>
+        <span className="ai-hub__status" data-state={status}>
+          {status === 'loading' ? <LoaderCircle aria-hidden="true" /> : status === 'ready' ? <Check aria-hidden="true" /> : <Globe2 aria-hidden="true" />}
+          {text[status]}
+        </span>
+      </header>
+
+      <dl className="ai-hub__metrics">
+        {text.metrics.map((label, index) => (
+          <div key={label}>
+            <dt>{label}</dt>
+            <dd>{metrics[index]}</dd>
+          </div>
+        ))}
+      </dl>
+
+      <div className="ai-hub__workspace">
+        <div className="ai-hub__modebar" role="group" aria-label={text.modeLabel}>
+          {(Object.keys(text.modes) as MachineResourceGroup[]).map((group) => (
+            <button
+              key={group}
+              type="button"
+              aria-pressed={mode === group}
+              onClick={() => setMode(group)}
+            >
+              {text.modes[group]}
+            </button>
+          ))}
+        </div>
+
+        <div className="ai-hub__resources" aria-live="polite">
+          {visibleResources.map((resource) => {
+            const [name, description] = text.resources[resource.id];
+            const href = `${basePath}${resource.path}`;
+            return (
+              <article className="ai-resource" key={resource.id}>
+                <span className="ai-resource__icon"><SourceIcon aria-hidden="true" /></span>
+                <div className="ai-resource__body">
+                  <div className="ai-resource__heading">
+                    <h3>{name}</h3>
+                    <span>{text.scope[resource.locale]}</span>
+                  </div>
+                  <p>{description}</p>
+                  <code>{resource.path}</code>
+                </div>
+                <div className="ai-resource__actions">
+                  <button
+                    type="button"
+                    title={text.copyUrl}
+                    aria-label={`${text.copyUrl}: ${name}`}
+                    onClick={() => copyText(new URL(href, window.location.origin).href, text.copiedUrl)}
+                  >
+                    <Copy aria-hidden="true" />
+                  </button>
+                  <a href={href} title={text.open} aria-label={`${text.open}: ${name}`}>
+                    <ExternalLink aria-hidden="true" />
+                  </a>
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="ai-hub__bootstrap">
+        <div className="ai-hub__bootstrap-title">
+          <span>{text.bootstrap}</span>
+          <strong>{text.bootstrapTitle}</strong>
+        </div>
+        <p>{text.prompt}</p>
+        <button type="button" onClick={() => copyText(text.prompt, text.copiedBootstrap)}>
+          <Copy aria-hidden="true" />{text.bootstrapCopy}
+        </button>
+      </div>
+
+      <footer className="ai-hub__trust">
+        {text.trust.map((item) => <span key={item}><ShieldCheck aria-hidden="true" />{item}</span>)}
+      </footer>
+      <span className="sr-only" aria-live="polite">{notice}</span>
+    </section>
+  );
+}

--- a/website/components/mdx.tsx
+++ b/website/components/mdx.tsx
@@ -6,6 +6,7 @@ import { LocalizedCodeBlock } from './localized-code-block';
 import { ReferenceMetadata } from './reference-metadata';
 import { ConfigValidator } from './config-validator';
 import { WaveformAnalyzer } from './waveform-analyzer';
+import { AIResourceHub } from './ai-resource-hub';
 
 export function getMDXComponents(components?: MDXComponents) {
   return createMDXComponents('en', components);
@@ -22,6 +23,7 @@ function createMDXComponents(locale: Language, components?: MDXComponents) {
     ReferenceMetadata,
     ConfigValidator,
     WaveformAnalyzer,
+    AIResourceHub,
     ...components,
   } satisfies MDXComponents;
 }

--- a/website/content/docs/en/ai/agent-workflow.mdx
+++ b/website/content/docs/en/ai/agent-workflow.mdx
@@ -1,0 +1,46 @@
+---
+title: Agent Workflow and Versioning
+description: Minimal-context retrieval, version pinning, and runtime verification for pmoke automation.
+---
+
+## Bootstrap
+
+Retrieve the concise index before loading documentation bodies:
+
+```bash
+curl -fsSL https://kerr-group.github.io/pmoke/llms.txt
+curl -fsSL https://kerr-group.github.io/pmoke/ai-index.json | jq '.pmoke_version, .source_commit'
+```
+
+The index links directly to processed per-page Markdown. Follow only the links
+required for the current task; do not ingest both full-language feeds by default.
+
+## Context ladder
+
+| Task | Preferred source | Runtime confirmation |
+| --- | --- | --- |
+| Explain one command | Per-page CLI Markdown | `pmoke <command> --help` |
+| Generate config | Config JSON + JSON Schema | `pmoke config validate` |
+| Diagnose connectivity | Installation and troubleshooting Markdown | `pmoke doctor hardware` |
+| Build broad English guidance | `llms-en.txt` | Relevant native command |
+| Compare English and Japanese terms | `llms-full.txt` | Source links and locale metadata |
+
+## Version pinning
+
+Record `pmoke_version`, `config_schema_version`, and `source_commit` from
+`ai-index.json` beside generated output. Reject a cached page when its SHA-256 digest
+does not match the corresponding manifest entry. Re-fetch the manifest when the
+requested pmoke version differs from the current feed.
+
+## Generation contract
+
+Agent output must retain exact field paths, units, enum values, command spelling,
+and canonical source URLs. Unsupported assumptions must remain explicit. Generated
+configuration is a proposal until native validation succeeds.
+
+```text
+Read the pmoke llms.txt index first. Select the smallest relevant locale-specific
+Markdown source. Prefer generated JSON contracts for exact CLI and config fields.
+Preserve versions, paths, units, and canonical URLs. Confirm configuration semantics
+with pmoke config validate. Do not infer hardware state, credentials, or addresses.
+```

--- a/website/content/docs/en/ai/index.mdx
+++ b/website/content/docs/en/ai/index.mdx
@@ -1,36 +1,28 @@
 ---
 title: AI and Machine Resources
-description: Stable documentation feeds for agents, editors, and automation.
+description: Versioned Markdown feeds, typed contracts, and local retrieval for reliable pmoke agents.
 ---
 
-## Endpoints
+Use this surface to select the smallest authoritative input for an agent, editor,
+or automation task. Every endpoint is static, versioned with the documentation
+build, and available without an account or API key.
 
-| Resource | Purpose |
-| --- | --- |
-| [`llms.txt`](/pmoke/llms.txt) | Concise bilingual page index |
-| [`llms-full.txt`](/pmoke/llms-full.txt) | Full processed documentation context |
-| [`llms-en.txt`](/pmoke/llms-en.txt) | English-only full context |
-| [`llms-ja.txt`](/pmoke/llms-ja.txt) | Japanese-only full context |
-| [`ai-index.json`](/pmoke/ai-index.json) | Versioned page manifest with SHA-256 digests |
-| [CLI JSON](/pmoke/generated/cli-reference.json) | Typed command and option tree |
-| [Config JSON](/pmoke/generated/config-reference.json) | Typed field registry |
-| [Config JSON Schema](/pmoke/config.schema.json) | Editor and structural validation schema |
+<AIResourceHub locale="en" />
 
-Every feed identifies the pmoke version, config schema version, and build source
-commit. Per-page Markdown URLs appear in page actions and preserve locale and
-canonical source information.
+## Retrieval order
 
-## Agent policy
+1. Start with [`llms.txt`](https://kerr-group.github.io/pmoke/llms.txt) for discovery.
+2. Fetch only the relevant per-page Markdown URL from the selected locale.
+3. Use generated JSON contracts for exact commands, options, fields, and defaults.
+4. Expand to a locale context feed only when the task spans several pages.
+5. Use the bilingual full feed only when cross-language context is required.
 
-1. Read `llms.txt` to select only relevant pages.
-2. Prefer the generated JSON over parsing rendered tables.
-3. Treat native `pmoke config validate` as authoritative for semantic validation.
-4. Preserve exact commands, field paths, units, and version metadata in generated output.
-5. Never infer private laboratory addresses from documentation examples.
+## Authority boundary
 
-## Search boundary
+Documentation describes supported behavior, but it cannot observe a workstation or
+instrument. `pmoke config validate` remains authoritative for configuration semantics;
+`pmoke doctor hardware` remains authoritative for compiled features and live hardware.
+An agent must not infer credentials, addresses, driver availability, or instrument state.
 
-The documentation search combines a deterministic bilingual concept-vector index
-with full-text results entirely in the browser. Queries and telemetry are not sent
-to pmoke, Orama Cloud, or another service. See [search and privacy](./search-privacy)
-for the model, fallback, and quality boundaries.
+Continue with [agent workflow and versioning](./agent-workflow), inspect the
+[resource contracts](./resource-contracts), or review [search and privacy](./search-privacy).

--- a/website/content/docs/en/ai/meta.json
+++ b/website/content/docs/en/ai/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "AI & Machine Resources",
-  "pages": ["index", "search-privacy"]
+  "pages": ["index", "agent-workflow", "resource-contracts", "search-privacy"]
 }

--- a/website/content/docs/en/ai/resource-contracts.mdx
+++ b/website/content/docs/en/ai/resource-contracts.mdx
@@ -1,0 +1,44 @@
+---
+title: Machine Resource Contracts
+description: Formats, stability boundaries, and integrity checks for exported machine resources.
+---
+
+## Contract map
+
+| Endpoint | Media type | Stability |
+| --- | --- | --- |
+| `llms.txt` | `text/plain; charset=utf-8` | Structured discovery index |
+| `llm/{lang}/{slug}.md` | `text/markdown; charset=utf-8` | Processed page content |
+| `llms-{lang}.txt` | `text/plain; charset=utf-8` | Locale context snapshot |
+| `ai-index.json` | `application/json` | Manifest schema 1 |
+| `generated/*.json` | `application/json` | Generated CLI/config contracts |
+| `config.schema.json` | `application/json` | Canonical config v4 structure |
+
+## Manifest record
+
+Each page entry contains locale, title, description, canonical HTML URL, Markdown
+URL, and a SHA-256 digest of the exact exported Markdown bytes. The manifest also
+identifies every top-level machine endpoint and its media type.
+
+```json
+{
+  "locale": "en",
+  "canonical_url": "https://kerr-group.github.io/pmoke/en/docs/quickstart/",
+  "markdown_url": "https://kerr-group.github.io/pmoke/llm/en/quickstart.md",
+  "sha256": "<64 lowercase hexadecimal characters>"
+}
+```
+
+## Integrity check
+
+```bash
+manifest=https://kerr-group.github.io/pmoke/ai-index.json
+url=$(curl -fsSL "$manifest" | jq -r '.pages[] | select(.locale == "en" and .title == "Quickstart") | .markdown_url')
+expected=$(curl -fsSL "$manifest" | jq -r '.pages[] | select(.locale == "en" and .title == "Quickstart") | .sha256')
+actual=$(curl -fsSL "$url" | sha256sum | cut -d' ' -f1)
+test "$actual" = "$expected"
+```
+
+Identical source commits produce deterministic feeds. New fields may be added to
+manifest schema 1; consumers must ignore unknown fields. A breaking shape change
+requires a schema increment.

--- a/website/content/docs/en/ai/search-privacy.mdx
+++ b/website/content/docs/en/ai/search-privacy.mdx
@@ -1,32 +1,34 @@
 ---
 title: Search and Privacy
-description: Local hybrid retrieval, quality gates, and full-text fallback boundaries.
+description: Browser-local hybrid retrieval, measurable quality gates, and explicit failure boundaries.
 ---
 
-## Local hybrid model
+## Local retrieval
 
-Search uses the deterministic `pmoke-domain-v1` bilingual concept projection. English
-and Japanese domain synonyms share concept dimensions, while bounded hashed lexical
-features preserve exact command names and configuration paths. The generated index
-contains public documentation only. Orama OSS performs text/vector ranking after a
-search begins; the semantic module is absent from the initial page payload.
+Search uses the deterministic `pmoke-domain-v1` bilingual concept projection.
+English and Japanese domain synonyms share concept dimensions; bounded hashed
+lexical features preserve exact commands and configuration paths. Orama OSS ranks
+the static records in the browser after the semantic module is loaded on demand.
 
-## Privacy boundary
+This is concept-vector retrieval, not a neural embedding service, generative answer
+engine, or cloud search product.
 
-- No query upload, analytics, cookies, account, or telemetry.
-- No indexing of local config files, CSV input, instrument addresses, or browser-tool state.
+## Data boundary
+
+- Public documentation as the only indexed content.
 - Same-origin static index delivery from GitHub Pages.
+- No query upload, analytics, cookie, account, or telemetry.
+- No indexing of local config, CSV input, instrument address, or browser-tool state.
 - No claim of complete offline support without a service worker.
 
 ## Failure boundary
 
-Failure to load the concept index or hybrid module leaves the locale-scoped ZBSearch
-full-text path available. The dialog announces **Full-text fallback** without blocking
-navigation or hiding results. English and Japanese indexes never mix.
+Failure to load Orama, the concept index, or the hybrid module leaves locale-scoped
+ZBSearch full-text retrieval available. The dialog reports **Full-text fallback**
+without blocking navigation or mixing English and Japanese indexes.
 
-## Quality boundary
+## Quality gate
 
 The versioned relevance fixture contains at least 40 queries per locale. CI requires
-Recall@5 of 0.85 or better for each locale, zero cross-locale leakage, warm p95 below
-100 ms, readiness below one second, and explicit static asset budgets. This is a
-domain concept-vector model, not a neural embedding, LLM answer engine, or cloud search.
+Recall@5 of at least 0.85 per locale, zero cross-locale leakage, warm p95 under
+100 ms, readiness under one second, and explicit static-asset budgets.

--- a/website/content/docs/en/configuration/reference.mdx
+++ b/website/content/docs/en/configuration/reference.mdx
@@ -9,7 +9,7 @@ description: Generated field reference for pmoke config schema version 4.
 
 <ReferenceMetadata pmokeVersion="0.4.0" schemaVersion={4} />
 
-[JSON Schema](/pmoke/config.schema.json) · [`pmoke config explain`](../../cli/reference#pmoke-config-explain)
+[JSON Schema](https://kerr-group.github.io/pmoke/config.schema.json) · [`pmoke config explain`](../../cli/reference#pmoke-config-explain)
 
 ## `version`
 

--- a/website/content/docs/en/configuration/validation.mdx
+++ b/website/content/docs/en/configuration/validation.mdx
@@ -14,7 +14,7 @@ Validation covers TOML syntax, unknown v4 keys, ranges, channel roles, filter
 constraints, connection URI syntax, and model/transport compatibility. It does not
 open an instrument.
 
-The editor schema is available as [config.schema.json](/pmoke/config.schema.json).
+The editor schema is available as [config.schema.json](https://kerr-group.github.io/pmoke/config.schema.json).
 Runtime validation remains authoritative for cross-field and hardware semantics.
 
 ## Browser validator

--- a/website/content/docs/ja/ai/agent-workflow.mdx
+++ b/website/content/docs/ja/ai/agent-workflow.mdx
@@ -1,0 +1,43 @@
+---
+title: Agent運用とVersion固定
+description: pmoke自動化向けの最小context取得、version固定、runtime確認。
+---
+
+## ブートストラップ
+
+documentation本文より先に取得する簡潔な索引。
+
+```bash
+curl -fsSL https://kerr-group.github.io/pmoke/llms.txt
+curl -fsSL https://kerr-group.github.io/pmoke/ai-index.json | jq '.pmoke_version, .source_commit'
+```
+
+処理済みpage別Markdownへの直接linkを持つ索引。既定での日英full feed一括投入ではなく、
+現在のtaskに必要なlinkだけの選択。
+
+## Context階層
+
+| Task | 優先source | Runtime確認 |
+| --- | --- | --- |
+| 単一commandの説明 | page別CLI Markdown | `pmoke <command> --help` |
+| config生成 | Config JSON + JSON Schema | `pmoke config validate` |
+| 通信診断 | installation・troubleshooting Markdown | `pmoke doctor hardware` |
+| 英語の横断的な案内 | `llms-en.txt` | 関連native command |
+| 日英用語の比較 | `llms-full.txt` | source link・locale metadata |
+
+## Version固定
+
+生成結果とともに記録する`ai-index.json`の`pmoke_version`、
+`config_schema_version`、`source_commit`。manifest entryのSHA-256 digestと一致しない
+cache pageの拒否。要求pmoke versionと現在のfeedが異なる場合のmanifest再取得。
+
+## 生成契約
+
+正確なfield path、unit、enum値、command表記、canonical source URLの保持。
+unsupported assumptionの明示。native validation成功前は提案状態となる生成config。
+
+```text
+最初にpmokeのllms.txt索引を参照。localeに対応する最小のMarkdown sourceを選択。
+正確なCLI・config fieldには生成JSON契約を優先。version、path、unit、canonical URLを保持。
+config semanticsはpmoke config validateで確認。hardware state、credential、addressの推測禁止。
+```

--- a/website/content/docs/ja/ai/index.mdx
+++ b/website/content/docs/ja/ai/index.mdx
@@ -1,33 +1,26 @@
 ---
-title: AI・機械向け Resource
-description: agent、editor、自動化向けの安定 documentation feed。
+title: AI・機械向けリソース
+description: 信頼できるpmoke agent向けのversioned Markdown feed、型付き契約、local検索。
 ---
 
-## endpoint
+agent、editor、自動化処理に必要な最小のauthoritative inputを選択するための操作面。
+account・API key不要、documentation buildと同じversionを持つ静的endpoint。
 
-| Resource | 用途 |
-| --- | --- |
-| [`llms.txt`](/pmoke/llms.txt) | 日英 page の簡潔な索引 |
-| [`llms-full.txt`](/pmoke/llms-full.txt) | 処理済み documentation の全 context |
-| [`llms-en.txt`](/pmoke/llms-en.txt) | 英語限定の full context |
-| [`llms-ja.txt`](/pmoke/llms-ja.txt) | 日本語限定の full context |
-| [`ai-index.json`](/pmoke/ai-index.json) | SHA-256 digest 付き versioned page manifest |
-| [CLI JSON](/pmoke/generated/cli-reference.json) | 型付き command・option tree |
-| [Config JSON](/pmoke/generated/config-reference.json) | 型付き field registry |
-| [Config JSON Schema](/pmoke/config.schema.json) | editor・構造検証向け schema |
+<AIResourceHub locale="ja" />
 
-pmoke version、config schema version、build source commit を含む各 feed。locale と canonical source 情報を保持する page 別 Markdown URL。
+## 取得順序
 
-## agent 方針
+1. 探索の起点となる [`llms.txt`](https://kerr-group.github.io/pmoke/llms.txt)。
+2. 選択localeから取得する関連page限定のMarkdown URL。
+3. 正確なcommand、option、field、default値に用いる生成JSON契約。
+4. 複数pageにまたがるtaskでのみ使用するlocale別context feed。
+5. 言語横断contextが必要な場合に限定する日英統合feed。
 
-1. 関連 page 選択の起点となる `llms.txt`。
-2. render 済み table の parse より優先する生成 JSON。
-3. semantic validation の最終基準となる native `pmoke config validate`。
-4. 生成結果で保持する正確な command、field path、unit、version metadata。
-5. documentation 例からの private 実験室 address 推測の禁止。
+## 権限境界
 
-## 検索境界
+workstation・測定装置の状態を観測しないdocumentation。config semanticsの最終基準となる
+`pmoke config validate`。compiled feature・live hardwareの最終基準となる
+`pmoke doctor hardware`。credential、address、driver availability、instrument stateの推測禁止。
 
-browser 内で完結する deterministic bilingual concept-vector index と全文検索結果の統合。
-pmoke、Orama Cloud、外部 service への query・telemetry 送信なし。
-model、fallback、品質境界の詳細となる [検索と privacy](./search-privacy)。
+次の参照先となる[agent運用とversion固定](./agent-workflow)、
+[resource契約](./resource-contracts)、[検索とprivacy](./search-privacy)。

--- a/website/content/docs/ja/ai/meta.json
+++ b/website/content/docs/ja/ai/meta.json
@@ -1,4 +1,4 @@
 {
-  "title": "AI・機械向け resource",
-  "pages": ["index", "search-privacy"]
+  "title": "AI・機械向けリソース",
+  "pages": ["index", "agent-workflow", "resource-contracts", "search-privacy"]
 }

--- a/website/content/docs/ja/ai/resource-contracts.mdx
+++ b/website/content/docs/ja/ai/resource-contracts.mdx
@@ -1,0 +1,42 @@
+---
+title: 機械向けResource契約
+description: export済み機械向けresourceの形式、安定性境界、integrity確認。
+---
+
+## 契約一覧
+
+| Endpoint | Media type | 安定性 |
+| --- | --- | --- |
+| `llms.txt` | `text/plain; charset=utf-8` | 構造化済み探索index |
+| `llm/{lang}/{slug}.md` | `text/markdown; charset=utf-8` | 処理済みpage content |
+| `llms-{lang}.txt` | `text/plain; charset=utf-8` | locale context snapshot |
+| `ai-index.json` | `application/json` | manifest schema 1 |
+| `generated/*.json` | `application/json` | 生成済みCLI・config契約 |
+| `config.schema.json` | `application/json` | canonical config v4構造 |
+
+## Manifest record
+
+locale、title、description、canonical HTML URL、Markdown URL、export済みMarkdown byte列の
+SHA-256 digestを持つ各page entry。top-level machine endpointとmedia typeを含むmanifest。
+
+```json
+{
+  "locale": "ja",
+  "canonical_url": "https://kerr-group.github.io/pmoke/ja/docs/quickstart/",
+  "markdown_url": "https://kerr-group.github.io/pmoke/llm/ja/quickstart.md",
+  "sha256": "<64 lowercase hexadecimal characters>"
+}
+```
+
+## Integrity確認
+
+```bash
+manifest=https://kerr-group.github.io/pmoke/ai-index.json
+url=$(curl -fsSL "$manifest" | jq -r '.pages[] | select(.locale == "ja" and .title == "クイックスタート") | .markdown_url')
+expected=$(curl -fsSL "$manifest" | jq -r '.pages[] | select(.locale == "ja" and .title == "クイックスタート") | .sha256')
+actual=$(curl -fsSL "$url" | sha256sum | cut -d' ' -f1)
+test "$actual" = "$expected"
+```
+
+同一source commitから生成されるdeterministic feed。manifest schema 1へのfield追加を許容する
+consumer側のunknown field無視。breaking shape変更時に必要となるschema更新。

--- a/website/content/docs/ja/ai/search-privacy.mdx
+++ b/website/content/docs/ja/ai/search-privacy.mdx
@@ -1,30 +1,32 @@
 ---
-title: 検索と Privacy
-description: local hybrid 検索、品質 gate、全文検索 fallback の境界。
+title: 検索とPrivacy
+description: browser-local hybrid検索、測定可能な品質gate、明示的なfailure境界。
 ---
 
-## local hybrid model
+## Local検索
 
-deterministic `pmoke-domain-v1` bilingual concept projection による検索。
-日英 domain synonym の共通 concept dimension と、正確な command 名・設定 path を保持する
-bounded hashed lexical feature。公開 documentation のみを対象とする生成 index。
-検索開始後に遅延読込される Orama OSS text/vector ranking。初期 page payload 外の semantic module。
+deterministic `pmoke-domain-v1` bilingual concept projectionによる検索。
+日英domain synonymの共通concept dimensionと、正確なcommand・config pathを保持する
+bounded hashed lexical feature。semantic moduleの遅延読込後にbrowser内でstatic recordを
+rankingするOrama OSS。
 
-## privacy 境界
+neural embedding service、生成回答engine、cloud検索productではないconcept-vector検索。
 
-- query upload、analytics、cookie、account、telemetry の不使用。
-- local config、CSV input、測定装置 address、browser tool state の非 index 化。
-- GitHub Pages からの同一 origin static index 配信。
-- service worker なしでの完全 offline 対応の非主張。
+## Data境界
 
-## failure 境界
+- index対象となる公開documentationのみ。
+- GitHub Pagesからの同一origin static index配信。
+- query upload、analytics、cookie、account、telemetryの不使用。
+- local config、CSV input、instrument address、browser tool stateの非index化。
+- service workerなしでの完全offline対応の非主張。
 
-concept index または hybrid module の読込失敗時にも利用可能な locale 限定 ZBSearch 全文検索。
-navigation と検索結果を維持したまま通知される **全文検索フォールバック**。
-日英 index 混在の禁止。
+## Failure境界
 
-## 品質境界
+Orama、concept index、hybrid moduleの読込失敗後も利用可能なlocale限定ZBSearch全文検索。
+navigationを妨げず、日英indexを混在させない **全文検索フォールバック** 表示。
 
-locale ごとに 40 query 以上の versioned relevance fixture。各 locale Recall@5 0.85 以上、
-cross-locale leakage なし、warm p95 100 ms 未満、readiness 1 秒未満、static asset budget を
-要求する CI。neural embedding、LLM answer engine、cloud search ではない domain concept-vector model。
+## 品質Gate
+
+localeごとに40 query以上のversioned relevance fixture。各locale Recall@5 0.85以上、
+cross-locale leakageなし、warm p95 100 ms未満、readiness 1秒未満、明示的static asset budgetを
+要求するCI gate。

--- a/website/content/docs/ja/configuration/reference.mdx
+++ b/website/content/docs/ja/configuration/reference.mdx
@@ -9,7 +9,7 @@ description: pmoke config schema version 4 の自動生成 field リファレン
 
 <ReferenceMetadata pmokeVersion="0.4.0" schemaVersion={4} />
 
-[JSON Schema](/pmoke/config.schema.json) · [`pmoke config explain`](../../cli/reference#pmoke-config-explain)
+[JSON Schema](https://kerr-group.github.io/pmoke/config.schema.json) · [`pmoke config explain`](../../cli/reference#pmoke-config-explain)
 
 ## `version`
 

--- a/website/content/docs/ja/configuration/validation.mdx
+++ b/website/content/docs/ja/configuration/validation.mdx
@@ -12,7 +12,7 @@ pmoke config explain lockin.filter
 
 TOML 構文、v4 未知 key、範囲、channel role、filter 制約、接続 URI、model/transport compatibility の検証。装置 open を伴わない静的検証。
 
-editor 向け [config.schema.json](/pmoke/config.schema.json)。cross-field・hardware semantics の最終基準となる runtime validation。
+editor 向け [config.schema.json](https://kerr-group.github.io/pmoke/config.schema.json)。cross-field・hardware semantics の最終基準となる runtime validation。
 
 ## ブラウザ設定検証
 

--- a/website/lib/llm-resources.ts
+++ b/website/lib/llm-resources.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 import { getLLMText, getPageMarkdownUrl, source } from '@/lib/source';
 import { absoluteUrl, siteOrigin } from '@/lib/shared';
+import { machineResources } from '@/lib/machine-resources';
 import { versionMetadata } from '@/lib/version';
 
 export async function buildFullLLMText(locales: string[] = ['en', 'ja']): Promise<string> {
@@ -41,6 +42,13 @@ export async function buildAIManifest() {
       search_query_upload: false,
       browser_tools_local_only: true,
     },
+    resources: machineResources.map((resource) => ({
+      id: resource.id,
+      url: absoluteUrl(resource.path),
+      media_type: resource.mediaType,
+      group: resource.group,
+      locale: resource.locale,
+    })),
     pages: await Promise.all(
       pages.map(async (page) => {
         const markdown = await getLLMText(page);

--- a/website/lib/machine-resources.ts
+++ b/website/lib/machine-resources.ts
@@ -1,0 +1,68 @@
+export type MachineResourceGroup = 'discovery' | 'context' | 'contract';
+
+export type MachineResource = {
+  id: string;
+  path: string;
+  mediaType: string;
+  group: MachineResourceGroup;
+  locale: 'en' | 'ja' | 'bilingual' | 'neutral';
+};
+
+export const machineResources = [
+  {
+    id: 'llms-index',
+    path: '/llms.txt',
+    mediaType: 'text/plain',
+    group: 'discovery',
+    locale: 'bilingual',
+  },
+  {
+    id: 'manifest',
+    path: '/ai-index.json',
+    mediaType: 'application/json',
+    group: 'discovery',
+    locale: 'bilingual',
+  },
+  {
+    id: 'english-context',
+    path: '/llms-en.txt',
+    mediaType: 'text/plain',
+    group: 'context',
+    locale: 'en',
+  },
+  {
+    id: 'japanese-context',
+    path: '/llms-ja.txt',
+    mediaType: 'text/plain',
+    group: 'context',
+    locale: 'ja',
+  },
+  {
+    id: 'full-context',
+    path: '/llms-full.txt',
+    mediaType: 'text/plain',
+    group: 'context',
+    locale: 'bilingual',
+  },
+  {
+    id: 'cli-contract',
+    path: '/generated/cli-reference.json',
+    mediaType: 'application/json',
+    group: 'contract',
+    locale: 'neutral',
+  },
+  {
+    id: 'config-contract',
+    path: '/generated/config-reference.json',
+    mediaType: 'application/json',
+    group: 'contract',
+    locale: 'neutral',
+  },
+  {
+    id: 'config-schema',
+    path: '/config.schema.json',
+    mediaType: 'application/json',
+    group: 'contract',
+    locale: 'neutral',
+  },
+] as const satisfies readonly MachineResource[];

--- a/website/scripts/serve-basepath.mjs
+++ b/website/scripts/serve-basepath.mjs
@@ -10,7 +10,8 @@ const port = Number(process.env.PORT ?? 4173);
 const mime = new Map([
   ['.css', 'text/css; charset=utf-8'], ['.html', 'text/html; charset=utf-8'],
   ['.js', 'text/javascript; charset=utf-8'], ['.json', 'application/json; charset=utf-8'],
-  ['.png', 'image/png'], ['.svg', 'image/svg+xml'], ['.txt', 'text/plain; charset=utf-8'],
+  ['.md', 'text/markdown; charset=utf-8'], ['.png', 'image/png'],
+  ['.svg', 'image/svg+xml'], ['.txt', 'text/plain; charset=utf-8'],
   ['.wasm', 'application/wasm'], ['.woff2', 'font/woff2'], ['.xml', 'application/xml; charset=utf-8'],
 ]);
 

--- a/website/scripts/smoke-deployment.mjs
+++ b/website/scripts/smoke-deployment.mjs
@@ -19,7 +19,7 @@ const checks = [
   { path: 'ja/docs/ai/search-privacy/', contains: 'local hybrid model' },
   { path: 'api/search', contains: 'Kerr' },
   { path: 'api/semantic-search', contains: 'pmoke-domain-v1' },
-  { path: 'llms.txt', contains: 'https://kerr-group.github.io/pmoke/en/docs/' },
+  { path: 'llms.txt', contains: 'https://kerr-group.github.io/pmoke/llm/en/' },
   { path: 'llms-en.txt', contains: '- locales: en' },
   { path: 'llms-ja.txt', contains: '- locales: ja' },
   { path: 'ai-index.json', contains: 'search_query_upload' },

--- a/website/scripts/verify-ai-resources.mjs
+++ b/website/scripts/verify-ai-resources.mjs
@@ -25,8 +25,31 @@ const manifest = JSON.parse(content.manifest);
 if (manifest.schema !== 1 || manifest.privacy?.search_query_upload !== false) {
   throw new Error('AI manifest schema or privacy boundary is invalid');
 }
-if (!Array.isArray(manifest.pages) || manifest.pages.length < 26) {
+if (!Array.isArray(manifest.pages) || manifest.pages.length < 30) {
   throw new Error('AI manifest is missing localized pages');
+}
+if (!Array.isArray(manifest.resources) || manifest.resources.length !== 8) {
+  throw new Error('AI manifest resource registry is incomplete');
+}
+const resourceIds = new Set(manifest.resources.map((resource) => resource.id));
+for (const required of ['llms-index', 'manifest', 'full-context', 'cli-contract', 'config-contract', 'config-schema']) {
+  if (!resourceIds.has(required)) throw new Error(`AI manifest is missing resource: ${required}`);
+}
+const resourceUrls = new Set();
+for (const resource of manifest.resources) {
+  const url = new URL(resource.url);
+  if (url.origin !== 'https://kerr-group.github.io' || !url.pathname.startsWith('/pmoke/')) {
+    throw new Error(`invalid machine resource URL: ${resource.url}`);
+  }
+  if (!['discovery', 'context', 'contract'].includes(resource.group)) {
+    throw new Error(`invalid machine resource group: ${resource.group}`);
+  }
+  if (typeof resource.media_type !== 'string' || resource.media_type.length === 0) {
+    throw new Error(`missing machine resource media type: ${resource.id}`);
+  }
+  if (resourceUrls.has(resource.url)) throw new Error(`duplicate machine resource URL: ${resource.url}`);
+  resourceUrls.add(resource.url);
+  await stat(path.join(output, url.pathname.slice('/pmoke/'.length)));
 }
 const seen = new Set();
 for (const page of manifest.pages) {
@@ -41,6 +64,16 @@ for (const page of manifest.pages) {
   const markdown = await readFile(exported);
   const digest = createHash('sha256').update(markdown).digest('hex');
   if (digest !== page.sha256) throw new Error(`Markdown digest mismatch: ${page.markdown_url}`);
+  if (!content.concise.includes(`(${page.markdown_url})`)) {
+    throw new Error(`llms.txt is missing Markdown page: ${page.markdown_url}`);
+  }
+}
+
+if (/\(https:\/\/kerr-group\.github\.io\/pmoke\/(?:en|ja)\/docs\//u.test(content.concise)) {
+  throw new Error('llms.txt links to rendered HTML instead of per-page Markdown');
+}
+for (const heading of ['## Machine contracts', '## English', '## 日本語', '## Optional']) {
+  if (!content.concise.includes(heading)) throw new Error(`llms.txt is missing section: ${heading}`);
 }
 
 const forbidden = [

--- a/website/scripts/verify-export.mjs
+++ b/website/scripts/verify-export.mjs
@@ -14,6 +14,8 @@ const required = [
   'ja/docs/quickstart/index.html',
   'en/docs/interactive/waveform-analyzer/index.html',
   'ja/docs/interactive/waveform-analyzer/index.html',
+  'en/docs/ai/index.html',
+  'ja/docs/ai/index.html',
   'llms.txt',
   'llms-full.txt',
   'llms-en.txt',
@@ -98,7 +100,7 @@ if (fixture.expected?.harmonics?.length !== 6 || fixture.license !== 'CC0-1.0') 
 }
 
 const search = await stat(path.join(output, 'api/search'));
-if (search.size > 900 * 1024) throw new Error(`M2 search budget exceeded: ${search.size} bytes`);
+if (search.size > 950 * 1024) throw new Error(`M2 search budget exceeded: ${search.size} bytes`);
 
 const semanticPath = path.join(output, 'api/semantic-search');
 const semanticFile = await readFile(semanticPath);

--- a/website/tests/ai-resources.spec.ts
+++ b/website/tests/ai-resources.spec.ts
@@ -1,0 +1,90 @@
+import { expect, test } from '@playwright/test';
+
+const visualProjects = new Set(['desktop-chromium', 'mobile-chromium']);
+
+test.beforeEach(async ({ page }, testInfo) => {
+  test.skip(!visualProjects.has(testInfo.project.name), 'Chromium AI resource contract');
+  await page.addInitScript(() => window.localStorage.setItem('pmoke-theme', 'dark'));
+});
+
+test('AI resource hub exposes live manifest and bounded endpoint modes', async ({ page, context }, testInfo) => {
+  await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+  const consoleErrors: string[] = [];
+  const failedResponses: string[] = [];
+  page.on('console', (message) => {
+    if (message.type() === 'error') consoleErrors.push(message.text());
+  });
+  page.on('response', (response) => {
+    if (response.status() >= 400) failedResponses.push(`${response.status()} ${response.url()}`);
+  });
+
+  await page.goto('/pmoke/en/docs/ai/');
+  const hub = page.locator('.ai-hub');
+  await expect(hub).toHaveAttribute('data-manifest', 'ready');
+  await expect(hub.getByText('MANIFEST ONLINE', { exact: true })).toBeVisible();
+  await expect(hub.locator('.ai-resource')).toHaveCount(2);
+
+  await hub.getByRole('button', { name: 'Context', exact: true }).click();
+  await expect(hub.locator('.ai-resource')).toHaveCount(3);
+  await hub.getByRole('button', { name: 'Copy endpoint URL: English context' }).click();
+  await expect.poll(() => page.evaluate(() => navigator.clipboard.readText()))
+    .toBe('http://127.0.0.1:4173/pmoke/llms-en.txt');
+
+  await hub.getByRole('button', { name: 'Contracts', exact: true }).click();
+  await expect(hub.locator('.ai-resource')).toHaveCount(3);
+  await expect(hub.getByRole('link', { name: 'Open resource: JSON Schema' }))
+    .toHaveAttribute('href', '/pmoke/config.schema.json');
+
+  const metrics = await hub.locator('.ai-hub__metrics dd').allTextContents();
+  expect(Number(metrics[0])).toBeGreaterThanOrEqual(30);
+  expect(metrics[1]).toBe('8');
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1)).toBeTruthy();
+  expect({ consoleErrors, failedResponses }).toEqual({ consoleErrors: [], failedResponses: [] });
+  await page.screenshot({ path: testInfo.outputPath('ai-resource-hub.png'), fullPage: true });
+});
+
+test('Japanese resource hub stays localized and responsive', async ({ page }, testInfo) => {
+  await page.goto('/pmoke/ja/docs/ai/');
+  const hub = page.locator('.ai-hub');
+  await expect(hub).toHaveAttribute('data-manifest', 'ready');
+  await expect(hub.getByRole('button', { name: 'コンテキスト', exact: true })).toBeVisible();
+  await expect(hub.getByText('最小コンテキスト優先', { exact: true })).toBeVisible();
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1)).toBeTruthy();
+  await page.screenshot({ path: testInfo.outputPath('ai-resource-hub-ja.png'), fullPage: true });
+});
+
+test('resource hub preserves static discovery when the manifest is unavailable', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'desktop-chromium', 'single-browser failure-mode gate');
+  await page.route('**/ai-index.json', (route) => route.abort());
+  await page.goto('/pmoke/en/docs/ai/');
+
+  const hub = page.locator('.ai-hub');
+  await expect(hub).toHaveAttribute('data-manifest', 'error');
+  await expect(hub.getByText('STATIC LINKS ONLY', { exact: true })).toBeVisible();
+  await expect(hub.locator('.ai-resource')).toHaveCount(2);
+  await expect(hub.getByRole('link', { name: 'Open resource: llms.txt' }))
+    .toHaveAttribute('href', '/pmoke/llms.txt');
+});
+
+test('machine feeds point to Markdown and publish an integrity manifest', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'desktop-chromium', 'single-browser machine feed gate');
+
+  const indexResponse = await page.request.get('/pmoke/llms.txt');
+  expect(indexResponse.ok()).toBeTruthy();
+  const index = await indexResponse.text();
+  expect(index).toContain('## Machine contracts');
+  expect(index).toContain('## Optional');
+  expect(index).toContain('https://kerr-group.github.io/pmoke/llm/en/quickstart.md');
+  expect(index).not.toContain('https://kerr-group.github.io/pmoke/en/docs/quickstart/');
+
+  const markdownResponse = await page.request.get('/pmoke/llm/en/quickstart.md');
+  expect(markdownResponse.ok()).toBeTruthy();
+  expect(markdownResponse.headers()['content-type']).toContain('text/markdown');
+
+  const manifestResponse = await page.request.get('/pmoke/ai-index.json');
+  const manifest = await manifestResponse.json();
+  expect(manifest.schema).toBe(1);
+  expect(manifest.resources).toHaveLength(8);
+  expect(manifest.pages.length).toBeGreaterThanOrEqual(30);
+  expect(manifest.pages.every((entry: { sha256: string }) => /^[a-f0-9]{64}$/u.test(entry.sha256))).toBeTruthy();
+});

--- a/website/tests/foundation.spec.ts
+++ b/website/tests/foundation.spec.ts
@@ -33,6 +33,8 @@ test('representative routes have no serious accessibility violations', async ({ 
     '/pmoke/ja/',
     '/pmoke/en/docs/quickstart/',
     '/pmoke/ja/docs/quickstart/',
+    '/pmoke/en/docs/ai/',
+    '/pmoke/ja/docs/ai/',
     '/pmoke/en/docs/configuration/validation/',
   ]) {
     await page.goto(route);

--- a/website/tests/static-site.spec.ts
+++ b/website/tests/static-site.spec.ts
@@ -51,7 +51,7 @@ test('deep documentation links and static search remain under the project base p
   expect(response.ok()).toBeTruthy();
   expect(await response.text()).toContain('クイックスタート');
   const llms = await page.request.get('/pmoke/llms.txt');
-  expect(await llms.text()).toContain('https://kerr-group.github.io/pmoke/ja/docs/');
+  expect(await llms.text()).toContain('https://kerr-group.github.io/pmoke/llm/ja/');
   expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBeTruthy();
   await page.screenshot({ path: testInfo.outputPath('ja-docs.png'), fullPage: true });
 });

--- a/xtask/src/markdown.rs
+++ b/xtask/src/markdown.rs
@@ -103,7 +103,7 @@ pub fn render_config(reference: &ConfigReference, locale: Locale) -> String {
     .unwrap();
     writeln!(
         output,
-        "[{schema_label}](/pmoke/config.schema.json) · [`pmoke config explain`](../../cli/reference#pmoke-config-explain)\n"
+        "[{schema_label}](https://kerr-group.github.io/pmoke/config.schema.json) · [`pmoke config explain`](../../cli/reference#pmoke-config-explain)\n"
     )
     .unwrap();
 


### PR DESCRIPTION
## Summary
- add a bilingual AI resource console with live manifest state, endpoint modes, copy/open actions, and static failure fallback
- publish a spec-aligned `llms.txt`, an endpoint registry in `ai-index.json`, and direct processed-Markdown discovery links
- add agent workflow, machine contract, search/privacy documentation, MIME handling, and integrity checks

## Verification
- `pnpm check`
- `pnpm build:site`
- `playwright test tests/ai-resources.spec.ts --project=desktop-chromium --project=mobile-chromium`
- `playwright test tests/foundation.spec.ts --project=desktop-chromium --grep='representative routes'`
- visual review at 1440x900 and 360x800
