### PR TITLE
fix(website): center AI resource icon

### DIFF
--- a/website/app/global.css
+++ b/website/app/global.css
@@ -494,7 +494,7 @@ html:not(.dark) .capability-grid p { color: #52615f; }
 }
 
 .ai-hub__mark svg { width: 1.1rem; height: 1.1rem; }
-.ai-hub__identity span,
+.ai-hub__identity > div > span,
 .ai-hub__bootstrap-title span {
   display: block;
   color: var(--cyan);

--- a/website/app/global.css
+++ b/website/app/global.css
@@ -731,17 +731,18 @@ html:not(.dark) .capability-grid p { color: #52615f; }
     grid-template-columns: repeat(3, minmax(0, 1fr));
     padding: 0;
     border-right: 0;
-    border-bottom: 1px solid var(--color-fd-border);
+    border-bottom: 0;
   }
   .ai-hub__modebar button {
     min-width: 0;
     border-left: 0;
-    border-bottom: 2px solid transparent;
+    border-bottom: 0;
+    box-shadow: inset 0 -1px 0 var(--color-fd-border);
     text-align: center;
   }
   .ai-hub__modebar button[aria-pressed='true'] {
     border-left-color: transparent;
-    border-bottom-color: var(--magenta);
+    box-shadow: inset 0 -2px 0 var(--magenta);
   }
   .ai-resource {
     grid-template-columns: 2rem minmax(0, 1fr);

--- a/website/tests/ai-resources.spec.ts
+++ b/website/tests/ai-resources.spec.ts
@@ -23,6 +23,19 @@ test('AI resource hub exposes live manifest and bounded endpoint modes', async (
   await expect(hub).toHaveAttribute('data-manifest', 'ready');
   await expect(hub.getByText('MANIFEST ONLINE', { exact: true })).toBeVisible();
   await expect(hub.locator('.ai-resource')).toHaveCount(2);
+  const mark = hub.locator('.ai-hub__mark');
+  await expect(mark).toHaveCSS('display', 'grid');
+  const markOffset = await mark.evaluate((element) => {
+    const container = element.getBoundingClientRect();
+    const icon = element.querySelector('svg')?.getBoundingClientRect();
+    if (!icon) return { x: Number.POSITIVE_INFINITY, y: Number.POSITIVE_INFINITY };
+    return {
+      x: Math.abs(container.left + container.width / 2 - (icon.left + icon.width / 2)),
+      y: Math.abs(container.top + container.height / 2 - (icon.top + icon.height / 2)),
+    };
+  });
+  expect(markOffset.x).toBeLessThanOrEqual(1);
+  expect(markOffset.y).toBeLessThanOrEqual(1);
 
   await hub.getByRole('button', { name: 'Context', exact: true }).click();
   await expect(hub.locator('.ai-resource')).toHaveCount(3);


### PR DESCRIPTION
## Summary
- prevent the AI hub kicker selector from overriding the icon mark's grid layout
- assert computed grid layout and sub-pixel SVG centering in browser tests

## Verification
- `pnpm lint`
- `pnpm types:check`
- `pnpm build:site`
- `playwright test tests/ai-resources.spec.ts --project=desktop-chromium --project=mobile-chromium`
- desktop visual inspection
