### PR TITLE
docs(website): add software citation reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,11 +145,14 @@ pmoke/
 | CLI reference | [Open](https://kerr-group.github.io/pmoke/en/docs/cli/reference/) | [開く](https://kerr-group.github.io/pmoke/ja/docs/cli/reference/) |
 | Configuration | [Open](https://kerr-group.github.io/pmoke/en/docs/configuration/reference/) | [開く](https://kerr-group.github.io/pmoke/ja/docs/configuration/reference/) |
 | Waveform analyzer | [Open](https://kerr-group.github.io/pmoke/en/docs/interactive/waveform-analyzer/) | [開く](https://kerr-group.github.io/pmoke/ja/docs/interactive/waveform-analyzer/) |
+| Citation & references | [Open](https://kerr-group.github.io/pmoke/en/docs/citation/) | [開く](https://kerr-group.github.io/pmoke/ja/docs/citation/) |
 
 ## 🔬 Publications
 
-If `pmoke` contributes to published work, cite the measurement method relevant
-to the experiment:
+If `pmoke` materially contributes to published work, consider citing the
+software version and the measurement method relevant to the experiment. See the
+[citation guide](https://kerr-group.github.io/pmoke/en/docs/citation/) for a
+version-pinned software citation and selection guidance.
 
 - A. Ikeda, S. Nakamura, S. Yamane, K. Noda, A. Ikeda, and S. Yonezawa,
   “Magneto-optical Kerr-effect measurements under pulsed magnetic fields over

--- a/website/app/api/search/route.ts
+++ b/website/app/api/search/route.ts
@@ -15,13 +15,13 @@ export const { staticGET: GET } = createFromSource(deterministicSource, {
     const structuredData = page.data.structuredData;
     if (!structuredData) throw new Error(`missing search data for ${page.url}`);
 
-    const isGeneratedReference = /\/(?:cli|configuration)\/reference$/u.test(page.url);
+    const shouldCompact = /\/(?:citation|(?:cli|configuration)\/reference)$/u.test(page.url);
     return {
       id: page.url,
       title: page.data.title,
       description: page.data.description,
       url: page.url,
-      structuredData: isGeneratedReference ? compactByHeading(structuredData) : structuredData,
+      structuredData: shouldCompact ? compactByHeading(structuredData) : structuredData,
     };
   },
 });

--- a/website/app/global.css
+++ b/website/app/global.css
@@ -122,6 +122,155 @@ pre,
   .reference-metadata > div:last-child { border-block-end: 0; }
 }
 
+.citation-panel {
+  margin: 2rem 0;
+  overflow: hidden;
+  border-block: 1px solid var(--color-fd-border);
+  background: color-mix(in srgb, var(--color-fd-card) 58%, transparent);
+}
+
+.citation-panel__header {
+  min-height: 74px;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid var(--color-fd-border);
+}
+
+.citation-panel__mark {
+  width: 2.35rem;
+  height: 2.35rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid color-mix(in srgb, var(--magenta) 42%, var(--color-fd-border));
+  color: var(--magenta);
+}
+
+.citation-panel__mark svg { width: 1rem; height: 1rem; }
+.citation-panel__header > div > span {
+  color: var(--color-fd-primary);
+  font: 650 0.62rem/1.2 var(--font-mono), monospace;
+  text-transform: uppercase;
+}
+.citation-panel__header h2 {
+  margin: 0.16rem 0 0;
+  font-size: 1rem;
+  line-height: 1.35;
+}
+.citation-panel__header > a,
+.citation-format button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--color-fd-border);
+  background: var(--color-fd-background);
+  color: var(--color-fd-muted-foreground);
+}
+.citation-panel__header > a { width: 2.2rem; height: 2.2rem; }
+.citation-panel__header > a:hover,
+.citation-format button:hover {
+  border-color: var(--color-fd-primary);
+  color: var(--color-fd-primary);
+}
+.citation-panel__header > a svg,
+.citation-format button svg { width: 0.95rem; height: 0.95rem; }
+
+.citation-panel__metadata {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin: 0;
+  border-bottom: 1px solid var(--color-fd-border);
+}
+.citation-panel__metadata > div {
+  min-width: 0;
+  padding: 0.6rem 1rem;
+  border-right: 1px solid var(--color-fd-border);
+}
+.citation-panel__metadata > div:last-child { border-right: 0; }
+.citation-panel__metadata dt {
+  color: var(--color-fd-muted-foreground);
+  font: 600 0.62rem/1.3 var(--font-inter), sans-serif;
+  text-transform: uppercase;
+}
+.citation-panel__metadata dd {
+  margin: 0.16rem 0 0;
+  overflow: hidden;
+  color: var(--color-fd-foreground);
+  font: 650 0.72rem/1.4 var(--font-mono), monospace;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.citation-panel__formats {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+}
+.citation-format { min-width: 0; }
+.citation-format:first-child { border-right: 1px solid var(--color-fd-border); }
+.citation-format > header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 42px;
+  padding: 0.45rem 0.7rem 0.45rem 1rem;
+  border-bottom: 1px solid var(--color-fd-border);
+}
+.citation-format > header > span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--color-fd-muted-foreground);
+  font: 650 0.65rem/1.2 var(--font-mono), monospace;
+  text-transform: uppercase;
+}
+.citation-format > header > span svg { width: 0.75rem; height: 0.75rem; color: var(--green); }
+.citation-format button { width: 1.9rem; height: 1.9rem; cursor: pointer; }
+.citation-format pre {
+  min-height: 10.5rem;
+  max-height: 17rem;
+  margin: 0;
+  overflow: auto;
+  padding: 0.9rem 1rem;
+  border: 0;
+  border-radius: 0;
+  background: color-mix(in srgb, var(--color-fd-background) 74%, transparent);
+  color: var(--color-fd-foreground);
+  font: 0.7rem/1.65 var(--font-mono), monospace;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+.citation-format pre code {
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+}
+.citation-format pre:focus-visible {
+  outline: 2px solid var(--color-fd-ring);
+  outline-offset: -2px;
+}
+
+@media (max-width: 720px) {
+  .citation-panel { margin-inline: -0.35rem; }
+  .citation-panel__metadata { grid-template-columns: 1fr; }
+  .citation-panel__metadata > div {
+    border-right: 0;
+    border-bottom: 1px solid var(--color-fd-border);
+  }
+  .citation-panel__metadata > div:last-child { border-bottom: 0; }
+  .citation-panel__formats { grid-template-columns: 1fr; }
+  .citation-format:first-child {
+    border-right: 0;
+    border-bottom: 1px solid var(--color-fd-border);
+  }
+  .citation-format pre { min-height: 0; max-height: none; }
+}
+
 button,
 a {
   border-radius: var(--radius);

--- a/website/components/citation-panel.tsx
+++ b/website/components/citation-panel.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { Check, Copy, GitBranch, Quote } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { pmokeVersion, sourceCommit } from '@/lib/version';
+
+type Locale = 'en' | 'ja';
+
+const repositoryUrl = 'https://github.com/Kerr-group/pmoke';
+
+const copy = {
+  en: {
+    aria: 'pmoke software citation',
+    kicker: 'SOFTWARE CITATION',
+    title: 'Reproducible attribution',
+    version: 'Version',
+    source: 'Source',
+    license: 'License',
+    plain: 'Plain text',
+    bibtex: 'BibTeX',
+    copyPlain: 'Copy plain-text citation',
+    copyBibtex: 'Copy BibTeX citation',
+    copiedPlain: 'Plain-text citation copied',
+    copiedBibtex: 'BibTeX citation copied',
+    copyFailed: 'Clipboard unavailable',
+    repository: 'Open source repository',
+  },
+  ja: {
+    aria: 'pmoke software citation',
+    kicker: 'SOFTWARE CITATION',
+    title: '再現可能な帰属情報',
+    version: 'Version',
+    source: 'Source',
+    license: 'License',
+    plain: 'テキスト',
+    bibtex: 'BibTeX',
+    copyPlain: 'テキスト引用のコピー',
+    copyBibtex: 'BibTeX引用のコピー',
+    copiedPlain: 'テキスト引用のコピー完了',
+    copiedBibtex: 'BibTeX引用のコピー完了',
+    copyFailed: 'クリップボード利用不可',
+    repository: 'source repositoryの表示',
+  },
+} as const;
+
+export function CitationPanel({ locale }: { locale: Locale }) {
+  const text = copy[locale];
+  const [notice, setNotice] = useState('');
+  const noticeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const shortCommit = sourceCommit === 'development' ? sourceCommit : sourceCommit.slice(0, 12);
+  const sourceNote = sourceCommit === 'development' ? 'development build' : `source ${sourceCommit}`;
+  const citation = `Kerr-group contributors (2026). pmoke (Version ${pmokeVersion}; ${sourceNote}) [Computer software]. GitHub. ${repositoryUrl}`;
+  const bibtex = useMemo(() => [
+    '@misc{kerr_group_pmoke_2026,',
+    '  author  = {{Kerr-group contributors}},',
+    '  title   = {pmoke: Pulsed-MOKE acquisition and analysis software},',
+    '  year    = {2026},',
+    `  version = {${pmokeVersion}},`,
+    `  url     = {${repositoryUrl}},`,
+    `  note    = {${sourceNote}},`,
+    '}',
+  ].join('\n'), [sourceNote]);
+
+  useEffect(() => () => {
+    if (noticeTimer.current) clearTimeout(noticeTimer.current);
+  }, []);
+
+  const copyText = async (value: string, success: string) => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setNotice(success);
+    } catch {
+      setNotice(text.copyFailed);
+    }
+    if (noticeTimer.current) clearTimeout(noticeTimer.current);
+    noticeTimer.current = setTimeout(() => setNotice(''), 2_000);
+  };
+
+  return (
+    <section className="citation-panel" aria-label={text.aria}>
+      <header className="citation-panel__header">
+        <span className="citation-panel__mark"><Quote aria-hidden="true" /></span>
+        <div>
+          <span>{text.kicker}</span>
+          <h2>{text.title}</h2>
+        </div>
+        <a href={repositoryUrl} aria-label={text.repository} title={text.repository}>
+          <GitBranch aria-hidden="true" />
+        </a>
+      </header>
+
+      <dl className="citation-panel__metadata">
+        <div><dt>{text.version}</dt><dd>{pmokeVersion}</dd></div>
+        <div><dt>{text.source}</dt><dd title={sourceCommit}>{shortCommit}</dd></div>
+        <div><dt>{text.license}</dt><dd>Apache-2.0</dd></div>
+      </dl>
+
+      <div className="citation-panel__formats">
+        <CitationFormat
+          label={text.plain}
+          copyLabel={text.copyPlain}
+          value={citation}
+          onCopy={() => copyText(citation, text.copiedPlain)}
+        />
+        <CitationFormat
+          label={text.bibtex}
+          copyLabel={text.copyBibtex}
+          value={bibtex}
+          onCopy={() => copyText(bibtex, text.copiedBibtex)}
+        />
+      </div>
+      <span className="sr-only" aria-live="polite">{notice}</span>
+    </section>
+  );
+}
+
+function CitationFormat({
+  label,
+  copyLabel,
+  value,
+  onCopy,
+}: {
+  label: string;
+  copyLabel: string;
+  value: string;
+  onCopy: () => void;
+}) {
+  return (
+    <div className="citation-format">
+      <header>
+        <span><Check aria-hidden="true" />{label}</span>
+        <button type="button" aria-label={copyLabel} title={copyLabel} onClick={onCopy}>
+          <Copy aria-hidden="true" />
+        </button>
+      </header>
+      <pre tabIndex={0}><code>{value}</code></pre>
+    </div>
+  );
+}

--- a/website/components/mdx.tsx
+++ b/website/components/mdx.tsx
@@ -7,6 +7,7 @@ import { ReferenceMetadata } from './reference-metadata';
 import { ConfigValidator } from './config-validator';
 import { WaveformAnalyzer } from './waveform-analyzer';
 import { AIResourceHub } from './ai-resource-hub';
+import { CitationPanel } from './citation-panel';
 
 export function getMDXComponents(components?: MDXComponents) {
   return createMDXComponents('en', components);
@@ -24,6 +25,7 @@ function createMDXComponents(locale: Language, components?: MDXComponents) {
     ConfigValidator,
     WaveformAnalyzer,
     AIResourceHub,
+    CitationPanel,
     ...components,
   } satisfies MDXComponents;
 }

--- a/website/content/docs/en/citation.mdx
+++ b/website/content/docs/en/citation.mdx
@@ -1,0 +1,46 @@
+---
+title: Citation & References
+description: How to cite pmoke software and select the pulsed-MOKE method papers relevant to an experiment.
+---
+
+When `pmoke` materially contributes to data acquisition, transformation, or analysis,
+consider citing the software in the resulting publication. Cite the measurement-method
+paper or papers that describe the experimental design actually used as well.
+
+<CitationPanel locale="en" />
+
+> The software citation identifies the executable analysis implementation. It does not
+> replace citations for the experimental method, hardware design, or scientific result.
+
+## What to cite
+
+| Contribution | Recommended citation |
+| --- | --- |
+| Acquisition, configuration validation, artifact management, or numerical analysis with `pmoke` | The software citation above, pinned to the version and source commit used |
+| Phase-resolved numerical lock-in with the compact sample-fiber fixture and all-fiber loopless Sagnac apparatus | Ikeda *et al.* (2026) |
+| Measurement under bipolar pulsed magnetic fields | Yamane *et al.* (2026) |
+| A modified method | The closest method paper, together with a description of the modification |
+
+## Method references
+
+1. A. Ikeda, S. Nakamura, S. Yamane, K. Noda, A. Ikeda, and S. Yonezawa,
+   “Magneto-optical Kerr-effect measurements under pulsed magnetic fields over
+   40 T using a compact sample fixture,” *Physical Review Research* **8**, 013169
+   (2026). [doi:10.1103/vy7j-ylb4](https://doi.org/10.1103/vy7j-ylb4)
+2. S. Yamane, S. Nakamura, A. Ikeda, K. Noda, A. Ikeda, and S. Yonezawa,
+   “Magneto-optical Kerr effect measurements under bipolar pulsed magnetic
+   fields,” *JJAP Conference Proceedings* **12**, 011011 (2026).
+   [doi:10.56646/jjapcp.12.0_011011](https://doi.org/10.56646/jjapcp.12.0_011011)
+
+## Reproducibility record
+
+Record the following alongside the citation:
+
+- exact `pmoke` version and source commit;
+- normalized `config.toml` and configuration schema version;
+- command line and enabled Cargo feature set;
+- input artifact identity and any analysis parameters changed after acquisition.
+
+The generated [CLI reference](./cli/reference) and
+[configuration reference](./configuration/reference) identify the behavior associated
+with the documentation build shown in the citation panel.

--- a/website/content/docs/en/meta.json
+++ b/website/content/docs/en/meta.json
@@ -8,6 +8,7 @@
     "interactive",
     "cli",
     "troubleshooting",
+    "citation",
     "ai"
   ]
 }

--- a/website/content/docs/ja/citation.mdx
+++ b/website/content/docs/ja/citation.mdx
@@ -1,0 +1,44 @@
+---
+title: 引用・参考文献
+description: pmoke softwareの引用方法と、実験条件に対応するパルスMOKE手法論文の選択指針。
+---
+
+`pmoke`によるdata取得・変換・解析が研究成果に実質的に寄与した場合のsoftware citation検討。
+実際に採用した実験設計を記述する測定手法論文の併記。
+
+<CitationPanel locale="ja" />
+
+> 実行可能な解析実装を特定するsoftware citation。実験手法、装置設計、科学的成果に対する
+> 文献引用との置換ではなく併記。
+
+## 引用対象
+
+| 寄与 | 推奨citation |
+| --- | --- |
+| `pmoke`による取得、設定検証、artifact管理、数値解析 | 使用version・source commitを固定した上記software citation |
+| compact sample-fiber fixture・all-fiber loopless Sagnac装置・phase-resolved numerical lock-in | Ikeda *et al.* (2026) |
+| bipolar pulsed magnetic field下の測定 | Yamane *et al.* (2026) |
+| 手法の変更を伴う利用 | 最も近い手法論文と変更内容の併記 |
+
+## 手法参考文献
+
+1. A. Ikeda, S. Nakamura, S. Yamane, K. Noda, A. Ikeda, and S. Yonezawa,
+   “Magneto-optical Kerr-effect measurements under pulsed magnetic fields over
+   40 T using a compact sample fixture,” *Physical Review Research* **8**, 013169
+   (2026). [doi:10.1103/vy7j-ylb4](https://doi.org/10.1103/vy7j-ylb4)
+2. S. Yamane, S. Nakamura, A. Ikeda, K. Noda, A. Ikeda, and S. Yonezawa,
+   “Magneto-optical Kerr effect measurements under bipolar pulsed magnetic
+   fields,” *JJAP Conference Proceedings* **12**, 011011 (2026).
+   [doi:10.56646/jjapcp.12.0_011011](https://doi.org/10.56646/jjapcp.12.0_011011)
+
+## 再現性記録
+
+citationと共に保存する情報:
+
+- `pmoke`の正確なversion・source commit
+- normalized `config.toml`・設定schema version
+- command line・有効化したCargo feature set
+- 入力artifactの識別情報・取得後に変更した解析parameter
+
+citation panelと同じdocumentation buildの動作を示す
+[CLIリファレンス](./cli/reference)・[設定リファレンス](./configuration/reference)。

--- a/website/content/docs/ja/meta.json
+++ b/website/content/docs/ja/meta.json
@@ -8,6 +8,7 @@
     "interactive",
     "cli",
     "troubleshooting",
+    "citation",
     "ai"
   ]
 }

--- a/website/scripts/smoke-deployment.mjs
+++ b/website/scripts/smoke-deployment.mjs
@@ -19,6 +19,8 @@ const checks = [
   { path: 'ja/docs/ai/', contains: 'エージェントリソースコンソール' },
   { path: 'en/docs/ai/search-privacy/', contains: 'Local retrieval' },
   { path: 'ja/docs/ai/search-privacy/', contains: 'Local検索' },
+  { path: 'en/docs/citation/', contains: 'Reproducible attribution' },
+  { path: 'ja/docs/citation/', contains: '再現可能な帰属情報' },
   { path: 'api/search', contains: 'Kerr' },
   { path: 'api/semantic-search', contains: 'pmoke-domain-v1' },
   { path: 'llms.txt', contains: 'https://kerr-group.github.io/pmoke/llm/en/' },

--- a/website/scripts/verify-export.mjs
+++ b/website/scripts/verify-export.mjs
@@ -16,6 +16,8 @@ const required = [
   'ja/docs/interactive/waveform-analyzer/index.html',
   'en/docs/ai/index.html',
   'ja/docs/ai/index.html',
+  'en/docs/citation/index.html',
+  'ja/docs/citation/index.html',
   'llms.txt',
   'llms-full.txt',
   'llms-en.txt',
@@ -48,6 +50,8 @@ const Japanese = await readFile(path.join(output, 'ja/index.html'), 'utf8');
 const JapaneseQuickstart = await readFile(path.join(output, 'ja/docs/quickstart/index.html'), 'utf8');
 const EnglishAnalyzer = await readFile(path.join(output, 'en/docs/interactive/waveform-analyzer/index.html'), 'utf8');
 const JapaneseAnalyzer = await readFile(path.join(output, 'ja/docs/interactive/waveform-analyzer/index.html'), 'utf8');
+const EnglishCitation = await readFile(path.join(output, 'en/docs/citation/index.html'), 'utf8');
+const JapaneseCitation = await readFile(path.join(output, 'ja/docs/citation/index.html'), 'utf8');
 const sitemap = await readFile(path.join(output, 'sitemap.xml'), 'utf8');
 const robots = await readFile(path.join(output, 'robots.txt'), 'utf8');
 if (!English.includes('<html lang="en"')) throw new Error('English lang metadata is missing');
@@ -58,6 +62,9 @@ if (!English.includes('/pmoke/_next/')) throw new Error('GitHub Pages basePath i
 if (!Japanese.includes('精密信号ラボ')) throw new Error('Japanese home content is missing');
 if (!EnglishAnalyzer.includes('waveform-analyzer')) throw new Error('English waveform tool is missing');
 if (!JapaneseAnalyzer.includes('波形アナライザー')) throw new Error('Japanese waveform tool is missing');
+if (!EnglishCitation.includes('Reproducible attribution')) throw new Error('English citation panel is missing');
+if (!JapaneseCitation.includes('再現可能な帰属情報')) throw new Error('Japanese citation panel is missing');
+if (!EnglishCitation.includes('10.1103/vy7j-ylb4')) throw new Error('Method DOI is missing from citation page');
 if (!JapaneseQuickstart.includes('https://kerr-group.github.io/pmoke/ja/docs/quickstart/')) {
   throw new Error('Canonical project URL is missing');
 }

--- a/website/tests/fixtures/search-relevance-v1.json
+++ b/website/tests/fixtures/search-relevance-v1.json
@@ -55,6 +55,8 @@
     { "locale": "en", "query": "required platform driver for direct GPIB", "expected": "/en/docs/installation" },
     { "locale": "en", "query": "raw waveform file error", "expected": "/en/docs/troubleshooting" },
     { "locale": "en", "query": "doctor checks for failed hardware", "expected": "/en/docs/troubleshooting" },
+    { "locale": "en", "query": "how to cite pmoke software", "expected": "/en/docs/citation" },
+    { "locale": "en", "query": "pulsed MOKE method paper DOI", "expected": "/en/docs/citation" },
 
     { "locale": "ja", "query": "pmoke とは何か", "expected": "/ja/docs" },
     { "locale": "ja", "query": "再現可能な測定と解析の概要", "expected": "/ja/docs" },
@@ -108,6 +110,8 @@
     { "locale": "ja", "query": "測定装置 timeout の診断", "expected": "/ja/docs/troubleshooting" },
     { "locale": "ja", "query": "direct GPIB に必要な platform driver", "expected": "/ja/docs/installation" },
     { "locale": "ja", "query": "raw waveform file error", "expected": "/ja/docs/troubleshooting" },
-    { "locale": "ja", "query": "失敗した hardware の doctor 確認", "expected": "/ja/docs/troubleshooting" }
+    { "locale": "ja", "query": "失敗した hardware の doctor 確認", "expected": "/ja/docs/troubleshooting" },
+    { "locale": "ja", "query": "pmoke software の引用方法", "expected": "/ja/docs/citation" },
+    { "locale": "ja", "query": "パルス MOKE 手法論文 DOI", "expected": "/ja/docs/citation" }
   ]
 }

--- a/website/tests/foundation.spec.ts
+++ b/website/tests/foundation.spec.ts
@@ -35,6 +35,8 @@ test('representative routes have no serious accessibility violations', async ({ 
     '/pmoke/ja/docs/quickstart/',
     '/pmoke/en/docs/ai/',
     '/pmoke/ja/docs/ai/',
+    '/pmoke/en/docs/citation/',
+    '/pmoke/ja/docs/citation/',
     '/pmoke/en/docs/configuration/validation/',
   ]) {
     await page.goto(route);
@@ -44,6 +46,23 @@ test('representative routes have no serious accessibility violations', async ({ 
     );
     expect(blocking, `${route}: ${blocking.map((violation) => violation.id).join(', ')}`).toEqual([]);
   }
+});
+
+test('citation reference is copyable and mobile-safe', async ({ page, context }, testInfo) => {
+  test.skip(testInfo.project.name !== 'desktop-chromium', 'single-browser citation gate');
+
+  await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+  await page.setViewportSize({ width: 320, height: 800 });
+  await page.goto('/pmoke/en/docs/citation/');
+  const panel = page.getByRole('region', { name: 'pmoke software citation' });
+  await expect(panel).toBeVisible();
+  await expect(panel.locator('.citation-panel__metadata dd').first()).toHaveText(/^\d+\.\d+\.\d+(?:[-+][\w.-]+)?$/u);
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth + 1))
+    .toBeTruthy();
+
+  await panel.getByRole('button', { name: 'Copy BibTeX citation' }).click();
+  await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toContain('@misc{kerr_group_pmoke_2026');
+  await expect(page.getByText('BibTeX citation copied')).toBeAttached();
 });
 
 test('config validator stays responsive and reports canonical v4 diagnostics', async ({ page }, testInfo) => {


### PR DESCRIPTION
## Summary
- add bilingual Citation & References pages to the documentation sidebar
- provide version- and source-pinned plain-text/BibTeX software citations with copy controls
- document the two pulsed-MOKE method papers and selection guidance
- cover search relevance, static export, deployment smoke, accessibility, clipboard, and mobile layout

## Verification
- `pnpm check`
- `pnpm build`
- `pnpm build:site`
- Playwright citation and representative accessibility gates with system Chrome
- desktop/mobile screenshot review

## References
- https://doi.org/10.1103/vy7j-ylb4
- https://doi.org/10.56646/jjapcp.12.0_011011