### PR TITLE
fix(website): allow Node patch releases

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -5,7 +5,7 @@
   "description": "Static bilingual documentation for the pmoke pulsed-MOKE CLI.",
   "packageManager": "pnpm@11.18.0",
   "engines": {
-    "node": "22.23.1"
+    "node": ">=22.23.1 <22.24.0"
   },
   "scripts": {
     "build": "npm run build:wasm && next build && node scripts/evaluate-search.mjs && node scripts/postbuild.mjs && node scripts/generate-release-metadata.mjs",


### PR DESCRIPTION
## Summary
- Accept Node versions from `22.23.1` through the `22.23.x` patch line.
- Keep CI and `.node-version` pinned to `22.23.1`; allow the Nix shell's `22.23.2` without an engine warning.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm check`
- `pnpm build`

No UI or generated files changed.