### PR TITLE
test(website): align Japanese deployment smoke marker

### DIFF
--- a/website/scripts/smoke-deployment.mjs
+++ b/website/scripts/smoke-deployment.mjs
@@ -18,7 +18,7 @@ const checks = [
   { path: 'en/docs/ai/', contains: 'Agent resource console' },
   { path: 'ja/docs/ai/', contains: 'エージェントリソースコンソール' },
   { path: 'en/docs/ai/search-privacy/', contains: 'Local retrieval' },
-  { path: 'ja/docs/ai/search-privacy/', contains: 'Local検索' },
+  { path: 'ja/docs/ai/search-privacy/', contains: 'ローカル検索' },
   { path: 'en/docs/citation/', contains: 'Reproducible attribution' },
   { path: 'ja/docs/citation/', contains: '再現可能な帰属情報' },
   { path: 'api/search', contains: 'Kerr' },


### PR DESCRIPTION
## Linked Issue

Refs #117

## Scope and outcome

- Outcome: align the public deployment smoke test with the intentional Japanese `ローカル検索` heading.
- Changed surfaces/files: `website/scripts/smoke-deployment.mjs` only.
- Non-goals preserved: no content, search behavior, API, generated reference, dependency, workflow-permission, or security-boundary changes.

## Current status

- [x] Root cause identified from the post-merge deployment log.
- [x] Acceptance criteria in Issue #117 are implemented locally.
- [x] Focused Nix validation passed.
- [ ] PR CI and post-merge deployment verification remain.
- [x] PR is Draft until the evidence below is complete.

## Review 1 — Issue, design, API, and security

- Requirement and ownership: the deployment smoke-test marker owns the release check for the Japanese search-privacy route; it must match the user-visible localized heading.
- Public API/config/schema/artifact compatibility: none; this is a release-test expectation only.
- Security boundary and data handling: unchanged; no new network target, credential, permission, or data path.
- Migration and rollback: one-line reversible marker update; revert this commit if the page contract changes intentionally.
- Decision: proceed with the focused test-contract fix.

## Review 2 — complete diff, tests, and generated artifacts

- [x] Complete staged diff reviewed; exactly one expected line changed.
- [x] `git diff --cached --check` passed.
- [x] No generated output is affected.
- [x] No secrets, credentials, private URLs, raw captures, personal data, or unreviewed logs are included.

## Validation evidence

- `nix develop --command bash -c 'node --check website/scripts/smoke-deployment.mjs; ...'`: passed; marker matches the generated Japanese page and the obsolete marker is absent.
- `nix develop --command bash -c 'cd website && pnpm check'`: passed with pnpm 11.18.0.
- Post-merge evidence being corrected: build, Browser/Accessibility/Visual, Lighthouse, and GitHub Pages deployment passed; the smoke test failed only because it expected the obsolete `Local検索` marker.

## UI evidence

- Route: `/pmoke/ja/docs/ai/search-privacy/`
- Locale/theme/viewport: static generated Japanese page; no UI behavior changed.
- Context: exported artifact marker verification.

## Residual risks and next work

- Residual risk: the full release contract must be re-run after merge.
- Next work: wait for PR CI, mark Ready when green, merge, then confirm the deployed-site smoke test.
- Post-merge verification needed: yes, required by the linked Issue.

## Handoff

- [ ] CI is green.
- [ ] PR is Ready for review.
- [ ] After merge, deployment/release verification is complete.
