### PR TITLE
chore: automate dependency updates and protect main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,85 @@
+version: 2
+
+updates:
+  # Cargo.lock is the source of truth for the Rust workspace dependency graph.
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    groups:
+      routine-rust-dependencies:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  # Dependabot's npm ecosystem supports pnpm lockfiles in website/.
+  - package-ecosystem: npm
+    directory: /website
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:10"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    groups:
+      routine-website-dependencies:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  # flake.lock is the source of truth for the Nix development environment.
+  - package-ecosystem: nix
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:20"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    groups:
+      routine-nix-inputs:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:30"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github
+    groups:
+      routine-github-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+# requirements.txt intentionally remains outside routine pip version updates
+# until its unpinned runtime dependencies have an explicit pinning policy.


### PR DESCRIPTION
Refs #119

## Current outcome
- Added `.github/dependabot.yml` for Cargo, website npm/pnpm, Nix flakes, and GitHub Actions.
- Grouped routine minor/patch updates while leaving security updates independent.
- Applied `main` branch protection for the single-maintainer workflow: pull request required, zero approvals, required CI/CodeQL checks, conversation resolution, and no force-push/deletion.

## Validation
- Dependabot YAML parsed successfully in the Nix development shell.
- `git diff --check` and staged Review 2 passed.
- GitHub API confirmed the `main` protection settings.

## Blockers
- None known.

## Residual risks
- Python routine version updates remain excluded until `requirements.txt` has an explicit pinning policy.
- Existing CodeQL findings are outside this configuration change and remain separately actionable.

## Next work
- Run the required pull request checks, then mark this PR ready and merge.