### PR TITLE
fix(website): approve esbuild 0.28.2 build

### DIFF
--- a/website/pnpm-workspace.yaml
+++ b/website/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 allowBuilds:
   esbuild@0.28.1: true
+  esbuild@0.28.2: true
   sharp: set this to true or false
   sharp@0.35.0: true
   unrs-resolver@1.12.2: true


### PR DESCRIPTION
Refs #129

## Current state
- Adds the exact `esbuild@0.28.2: true` entry to the existing website pnpm `allowBuilds` policy.
- Keeps the existing exact `esbuild@0.28.1` approval so main remains installable while #126 is evaluated.
- Does not change application code, the lockfile, Node/pnpm pins, or the public site contract.

## Validation
- Nix shell: `pnpm install --frozen-lockfile`
- Nix shell: `pnpm check`
- Nix shell: `pnpm test:licenses`
- Nix shell: `pnpm build`
- All passed. Nix provides Node `22.23.2` while the repository pin is `22.23.1`; pnpm is `11.18.0` as pinned.

## Blocker
- The Dependabot PR #126 must be rebased after this policy change and run through its complete website CI.

## Residual risks
- Exact-version approvals intentionally require a reviewed allowlist update for future esbuild versions.
- The existing `sharp` and `unrs-resolver` approvals are unchanged.

## Next work
- Review the complete CI result after #126 is rebased.
- Mark this PR ready only after its checks and the dependent PR validation are complete.