### PR TITLE
chore(governance): remove draft pull request phase

### DIFF
--- a/.agents/skills/pmoke-maintenance/SKILL.md
+++ b/.agents/skills/pmoke-maintenance/SKILL.md
@@ -38,15 +38,18 @@ compatibility, or security contract. Keep the public work-item split explicit:
 - Use one GitHub Issue for each durable user-facing goal. The Issue should state
   the purpose, scope, non-goals, acceptance criteria, compatibility impact,
   security impact, design decision, and validation plan.
-- When implementation starts, create a Draft PR linked with `Refs #N`. Keep
+- When implementation starts, create a normal PR linked with `Refs #N` and
+  keep it open for review from the beginning; do not use a Draft PR phase. Keep
   the PR description limited to the current outcome, changed surface,
   validation evidence, blockers, residual risks, and next work; do not write a
   chronological diary.
 - Review 1 records the Issue/design/API/security decision. Review 2 records the
-  complete staged diff, tests, and generated artifacts. Mark the PR ready only
-  after the acceptance criteria and validation evidence are complete. After
-  merge, perform deployment/release verification when applicable, then close
-  the Issue explicitly.
+  complete staged diff, tests, and generated artifacts. Merge only after the
+  acceptance criteria and validation evidence are complete, the current head
+  is up to date, required and relevant checks pass on that head, conversations
+  are resolved, and no blocking review remains. After merge, perform
+  deployment/release verification when applicable, then close the Issue
+  explicitly.
 - Use `SECURITY.md` for vulnerability reporting. Never put vulnerability
   details, credentials, private URLs, raw captures, or exploit material in a
   public Issue or PR. A GitHub Project is optional and is only a dashboard;

--- a/.agents/skills/pmoke-website/SKILL.md
+++ b/.agents/skills/pmoke-website/SKILL.md
@@ -36,12 +36,13 @@ its absence instead of downloading one through a package manager.
 Preserve the `/pmoke/` base path, static export behavior, English/Japanese
 parity, no-JavaScript readability, and bounded worker/WASM failure recovery.
 Treat generated references and release metadata as owned by their generators.
-For a durable website goal, use the repository's public Issue → Draft PR
-workflow. Keep the Issue's acceptance, compatibility, and security decisions
-separate from the PR's current validation state. Put UI evidence in the Issue
-or PR with route, locale, viewport, theme, and dev/export context; do not add
-an unredacted screenshot, recording, log, endpoint, or personal path to the
-repository.
+For a durable website goal, use the repository's public Issue → normal PR
+workflow. Open the PR when implementation starts and keep it available for
+review; do not use a Draft PR phase. Keep the Issue's acceptance,
+compatibility, and security decisions separate from the PR's current
+validation state. Put UI evidence in the Issue or PR with route, locale,
+viewport, theme, and dev/export context; do not add an unredacted screenshot,
+recording, log, endpoint, or personal path to the repository.
 
 ## UI-first workflow
 
@@ -123,12 +124,12 @@ repository.
 
 ## Public progress and handoff
 
-Use a GitHub Issue for the durable user-facing goal, a Draft PR for active work,
-and the PR description for a concise checklist of scope, visible outcome,
-validation, screenshots, and blockers. Keep private deliberation and temporary
-notes out of tracked files. Use README/docs for stable instructions and a
-changelog for released user-visible changes; do not add a chronological public
-work diary unless the project explicitly wants one.
+Use a GitHub Issue for the durable user-facing goal, a normal PR opened at the
+start of active work, and the PR description for a concise checklist of scope,
+visible outcome, validation, screenshots, and blockers. Keep private
+deliberation and temporary notes out of tracked files. Use README/docs for
+stable instructions and a changelog for released user-visible changes; do not
+add a chronological public work diary unless the project explicitly wants one.
 
 For UI checkpoints, record the route, locale, viewport, theme, and whether the
 evidence came from `next dev` or the exported site. Never include tokens,

--- a/.github/ISSUE_TEMPLATE/project-goal.yml
+++ b/.github/ISSUE_TEMPLATE/project-goal.yml
@@ -75,7 +75,7 @@ body:
     attributes:
       label: Proposed design and rollback
       description: Summarize the intended design, alternatives considered, and how the change can be disabled or reverted.
-      placeholder: Keep implementation details concise; the linked Draft PR will carry the active implementation state.
+      placeholder: Keep implementation details concise; the linked PR will carry the active implementation state.
     validations:
       required: true
   - type: textarea
@@ -110,4 +110,4 @@ body:
       value: |
         ## Review 1 — maintainer record
 
-        Record the design, public API/compatibility, security, and rollback decision here before implementation is treated as accepted. Start implementation in a linked Draft PR with `Refs #N`.
+        Record the design, public API/compatibility, security, and rollback decision here before implementation is treated as accepted. Start implementation in a linked normal PR with `Refs #N` and keep it open for review from the beginning.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,9 +12,9 @@ Refs #<!-- one durable goal per Issue; use an auto-closing keyword only after po
 
 ## Current status
 
-- [ ] Acceptance criteria in the linked Issue are complete.
-- [ ] This PR is still Draft while implementation or validation remains.
-- [ ] This PR is Ready for review only after the evidence below is complete.
+- [ ] This normal PR is open for review from implementation start.
+- [ ] Acceptance criteria in the linked Issue are complete before merge.
+- [ ] Current head, required checks, relevant validation, and blockers are current.
 
 ## Review 1 — Issue, design, API, and security
 
@@ -54,11 +54,12 @@ Refs #<!-- one durable goal per Issue; use an auto-closing keyword only after po
 ## Residual risks and next work
 
 - Residual risk:
-- Next work before Ready/merge:
+- Next work before merge:
 - Post-merge or release verification needed:
 
 ## Handoff
 
 - [ ] CI is green or the remaining failure is explicitly explained.
-- [ ] The PR is ready for review.
+- [ ] Review 1 and Review 2 are complete and no blocking review remains.
+- [ ] The current head is up to date and conversations are resolved.
 - [ ] After merge, required deployment/release verification will be completed before closing the linked Issue.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,20 +243,21 @@ split:
   `docs/project/requirements.md` contains stable product requirements,
   compatibility promises, and security boundaries; GitHub Issues contain the
   purpose, scope, non-goals, acceptance criteria, compatibility impact, and
-  security impact of a durable goal; Draft PRs contain the active
-  implementation state and validation evidence; `SECURITY.md` contains private
+  security impact of a durable goal; PRs contain the active implementation
+  state and validation evidence; `SECURITY.md` contains private
   vulnerability-reporting instructions. A GitHub Project may provide an
   optional dashboard, but it is not a requirements or status source of truth.
-- Track one durable, user-facing goal in a GitHub Issue; use a Draft PR for
-  active implementation and its description for a short scope/outcome/
-  validation/blocker checklist.
-- When implementation starts, link the Draft PR to the Issue with `Refs #N`.
-  Keep the PR in Draft while work or validation remains; record Review 1 on the
-  Issue or design discussion and Review 2 on the complete staged PR diff,
-  tests, and generated artifacts. Mark the PR Ready for review only after the
-  acceptance criteria and validation evidence are complete. Merge first, then
-  perform any required deployment or release verification and close the Issue
-  explicitly.
+- Track one durable, user-facing goal in a GitHub Issue; open a normal linked
+  PR when implementation starts and keep its description as a short
+  scope/outcome/validation/blocker checklist. Do not use a Draft PR phase.
+- When implementation starts, link the PR to the Issue with `Refs #N` and keep
+  it open for review from the beginning. Record Review 1 on the Issue or design
+  discussion and Review 2 on the complete staged PR diff, tests, and generated
+  artifacts. Merge only after the acceptance criteria and validation evidence
+  are complete, the current head is up to date, required and relevant checks
+  pass on that head, conversations are resolved, and no blocking review remains.
+  With explicit maintainer authorization, merge first, then perform any
+  required deployment or release verification and close the Issue explicitly.
 - Record stable instructions in README or docs and released user-visible
   changes in the changelog. Do not turn the repository into a chronological
   progress diary or commit private deliberation.

--- a/README.md
+++ b/README.md
@@ -191,8 +191,8 @@ pmoke/
 
 Stable product, compatibility, and security boundaries are documented in the
 [project requirements](docs/project/requirements.md). Public work follows one
-GitHub Issue per durable goal, a linked Draft PR for implementation, and
-explicit validation before the PR is marked ready. See the
+GitHub Issue per durable goal, a linked normal PR opened when implementation
+starts, and explicit validation before merge. See the
 [security policy](SECURITY.md) for private vulnerability reporting; do not
 disclose security details in public Issues or PRs.
 

--- a/docs/project/requirements.md
+++ b/docs/project/requirements.md
@@ -84,13 +84,15 @@ The following surfaces are part of the product contract:
 
 Every durable public change has one Issue with purpose, scope, non-goals,
 acceptance criteria, compatibility impact, and security impact. Implementation
-starts in a linked Draft PR. Review 1 covers the Issue, design, API or public
-contract, compatibility, security, and rollback decision. Review 2 covers the
-complete staged diff, tests, generated outputs, and public-artifact hygiene.
+starts in a linked normal PR that is open for review from the beginning. Review
+1 covers the Issue, design, API or public contract, compatibility, security,
+and rollback decision. Review 2 covers the complete staged diff, tests,
+generated outputs, and public-artifact hygiene.
 
 A change is ready for merge only when its acceptance criteria and relevant
-validation evidence are complete, known limitations are stated, and the PR has
-been marked ready for review. After merge, deployment or release verification
-is completed when applicable before the Issue is closed. User-visible release
-changes are recorded in `CHANGELOG.md`; temporary planning and private
-deliberation stay out of the repository.
+validation evidence are complete, known limitations are stated, the current PR
+head is up to date, required and relevant checks pass on that head,
+conversations are resolved, and no blocking review remains. After merge,
+deployment or release verification is completed when applicable before the
+Issue is closed. User-visible release changes are recorded in `CHANGELOG.md`;
+temporary planning and private deliberation stay out of the repository.


### PR DESCRIPTION
Refs #131

## Scope and outcome

- Remove the Draft PR phase from repository guidance, skills, project requirements, and GitHub Issue/PR templates.
- Keep Issue tracking, Review 1, Review 2, validation evidence, public-artifact hygiene, and explicit post-merge Issue closure.
- Define agent-led merge gates for current-head CI, branch freshness, resolved conversations, no blocking review, and explicit maintainer authorization.
- Do not change GitHub native auto-merge or branch protection settings.

## Current status

- This is a normal PR and is open for review from implementation start.
- The change is limited to seven English governance/template files.

## Review 1 — Issue, design, API, and security

- Requirement and ownership: documented in #131; collaboration state changes only.
- Compatibility: no application, API, route, schema, artifact, or CI behavior changes.
- Security: Draft status is removed without weakening required checks, conversation resolution, review records, or public secret hygiene.
- Decision: merge after the current head passes CI and the handoff checks below are complete.

## Review 2 — complete diff, tests, and generated artifacts

- Complete staged diff reviewed: seven expected guidance/template files only.
- No generated output, credentials, private URLs, raw captures, or build products are included.
- `rg` confirms no remaining instruction requiring Draft PR status.

## Validation evidence

- Nix shell: `pnpm check` passed.
- `git diff --check` passed.
- Node: Nix `22.23.2`; repository pin `22.23.1` remains unchanged.
- pnpm: `11.18.0`.

## Residual risks and next work

- GitHub native auto-merge remains disabled and is a separate future setting decision.
- After merge, close #131 and verify the branch is automatically deleted.

## Handoff

- CI is pending on this current head.
- Merge only after required and relevant checks pass, the branch is up to date, conversations are resolved, and no blocking review remains.