### PR TITLE
fix: harden phase-analysis input contracts

### DIFF
--- a/crates/pmoke-analysis-core/src/phase.rs
+++ b/crates/pmoke-analysis-core/src/phase.rs
@@ -1,7 +1,27 @@
-pub fn rotate_phase(lix: &[f64], liy: &[f64], delta: f64) -> (Vec<f64>, Vec<f64>) {
+use crate::error::{AnalysisError, Result};
+
+pub fn rotate_phase(lix: &[f64], liy: &[f64], delta: f64) -> Result<(Vec<f64>, Vec<f64>)> {
+    if lix.len() != liy.len() {
+        return Err(AnalysisError::new(
+            "length_mismatch",
+            format!(
+                "phase rotation requires equal-length x and y arrays (got {} and {})",
+                lix.len(),
+                liy.len()
+            ),
+        ));
+    }
+    if !delta.is_finite() || lix.iter().chain(liy).any(|value| !value.is_finite()) {
+        return Err(AnalysisError::new(
+            "non_finite_phase",
+            "phase rotation x, y, and delta must be finite",
+        ));
+    }
+
     let cos_delta = delta.cos();
     let sin_delta = delta.sin();
-    lix.iter()
+    Ok(lix
+        .iter()
         .zip(liy)
         .map(|(&x, &y)| {
             (
@@ -9,7 +29,7 @@ pub fn rotate_phase(lix: &[f64], liy: &[f64], delta: f64) -> (Vec<f64>, Vec<f64>
                 -x * sin_delta + y * cos_delta,
             )
         })
-        .unzip()
+        .unzip())
 }
 
 #[cfg(test)]
@@ -18,13 +38,40 @@ mod tests {
 
     #[test]
     fn rotation_preserves_magnitude() {
-        let (rotated_x, rotated_y) = rotate_phase(&[3.0, -1.0], &[4.0, 2.0], 0.73);
+        let (rotated_x, rotated_y) = rotate_phase(&[3.0, -1.0], &[4.0, 2.0], 0.73).unwrap();
         for ((x, y), expected) in rotated_x
             .iter()
             .zip(&rotated_y)
             .zip([5.0_f64, 5.0_f64.sqrt()])
         {
             assert!((x.hypot(*y) - expected).abs() < 1.0e-12);
+        }
+    }
+
+    #[test]
+    fn mismatched_lengths_are_rejected_before_rotation() {
+        let error = rotate_phase(&[1.0, 2.0], &[3.0], 0.2).unwrap_err();
+
+        assert_eq!(error.code(), "length_mismatch");
+        assert_eq!(
+            error.message(),
+            "phase rotation requires equal-length x and y arrays (got 2 and 1)"
+        );
+    }
+
+    #[test]
+    fn non_finite_inputs_are_rejected() {
+        for (x, y, delta) in [
+            (vec![f64::NAN], vec![1.0], 0.2),
+            (vec![1.0], vec![f64::INFINITY], 0.2),
+            (vec![1.0], vec![2.0], f64::NEG_INFINITY),
+        ] {
+            let error = rotate_phase(&x, &y, delta).unwrap_err();
+            assert_eq!(error.code(), "non_finite_phase");
+            assert_eq!(
+                error.message(),
+                "phase rotation x, y, and delta must be finite"
+            );
         }
     }
 }

--- a/crates/pmoke-analysis-core/tests/pipeline.rs
+++ b/crates/pmoke-analysis-core/tests/pipeline.rs
@@ -89,7 +89,7 @@ fn shared_pipeline_recovers_the_reference_kerr_fixture() {
                 },
             )
             .unwrap();
-            let rotated = rotate_phase(&output.x, &output.y, parameters.rotation_rad);
+            let rotated = rotate_phase(&output.x, &output.y, parameters.rotation_rad).unwrap();
             (output, rotated)
         })
         .collect::<Vec<_>>();

--- a/crates/pmoke-web-wasm/src/lib.rs
+++ b/crates/pmoke-web-wasm/src/lib.rs
@@ -109,17 +109,8 @@ pub fn rotate_phase_interleaved(
     y: &[f64],
     delta_rad: f64,
 ) -> Result<Box<[f64]>, JsError> {
-    if x.len() != y.len() {
-        return Err(JsError::new(
-            "length_mismatch: x and y must have equal lengths",
-        ));
-    }
-    if !delta_rad.is_finite() || x.iter().chain(y).any(|value| !value.is_finite()) {
-        return Err(JsError::new(
-            "non_finite_phase: x, y, and delta must be finite",
-        ));
-    }
-    let (in_phase, out_of_phase) = pmoke_analysis_core::rotate_phase(x, y, delta_rad);
+    let (in_phase, out_of_phase) =
+        pmoke_analysis_core::rotate_phase(x, y, delta_rad).map_err(analysis_error)?;
     let mut packed = Vec::with_capacity(x.len() * 2);
     for (in_phase, out_of_phase) in in_phase.into_iter().zip(out_of_phase) {
         packed.extend_from_slice(&[in_phase, out_of_phase]);
@@ -203,6 +194,32 @@ mod tests {
         let output = generate_signal(usize::MAX, 0.25);
         assert_eq!(output.len(), MAX_SAMPLES * 4);
         assert!(output.iter().all(|value| value.is_finite()));
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[test]
+    fn phase_rotation_preserves_shared_error_codes() {
+        let length_error = rotate_phase_interleaved(&[1.0, 2.0], &[3.0], 0.2).unwrap_err();
+        assert!(
+            JsValue::from(length_error)
+                .as_string()
+                .unwrap()
+                .starts_with("length_mismatch:")
+        );
+
+        for (x, y, delta) in [
+            (vec![f64::NAN], vec![1.0], 0.2),
+            (vec![1.0], vec![f64::INFINITY], 0.2),
+            (vec![1.0], vec![2.0], f64::NAN),
+        ] {
+            let error = rotate_phase_interleaved(&x, &y, delta).unwrap_err();
+            assert!(
+                JsValue::from(error)
+                    .as_string()
+                    .unwrap()
+                    .starts_with("non_finite_phase:")
+            );
+        }
     }
 
     #[test]

--- a/src/phase/mod.rs
+++ b/src/phase/mod.rs
@@ -143,12 +143,28 @@ pub fn run_phase_analysis(
 }
 
 pub fn phase_analysis(cfg: &Config, li_result: &[Vec<f64>]) -> Result<PhaseAnalysisOutput> {
-    if li_result.len() < 12 {
+    if li_result.len() != LI_HEADER.len() {
         bail!(
-            "phase analysis requires 12 lock-in columns (six x/y pairs), got {}",
+            "length_mismatch: phase analysis requires exactly {} lock-in columns (six x/y pairs), got {}",
+            LI_HEADER.len(),
             li_result.len()
         );
     }
+
+    if li_result.iter().any(Vec::is_empty) {
+        bail!("empty_phase_column: phase analysis columns must not be empty");
+    }
+    let sample_count = li_result[0].len();
+    if li_result.iter().any(|column| column.len() != sample_count) {
+        bail!(
+            "length_mismatch: phase analysis columns must have equal lengths (expected {}, found another length)",
+            sample_count
+        );
+    }
+    if li_result.iter().flatten().any(|value| !value.is_finite()) {
+        bail!("non_finite_phase: phase analysis columns must contain only finite values");
+    }
+
     let pairs: Vec<_> = li_result.chunks_exact(2).collect();
 
     let [
@@ -244,12 +260,12 @@ pub fn phase_analysis(cfg: &Config, li_result: &[Vec<f64>]) -> Result<PhaseAnaly
     let delta_6 = PI / 2.0 - 6.0 * omega_t0;
     let deltas = [delta_1, delta_2, delta_3, delta_4, delta_5, delta_6];
 
-    let (li1_in, li1_out) = rotate_phase(li1x, li1y, delta_1);
-    let (li2_in, li2_out) = rotate_phase(li2x, li2y, delta_2);
-    let (li3_in, li3_out) = rotate_phase(li3x, li3y, delta_3);
-    let (li4_in, li4_out) = rotate_phase(li4x, li4y, delta_4);
-    let (li5_in, li5_out) = rotate_phase(li5x, li5y, delta_5);
-    let (li6_in, li6_out) = rotate_phase(li6x, li6y, delta_6);
+    let (li1_in, li1_out) = rotate_phase(li1x, li1y, delta_1)?;
+    let (li2_in, li2_out) = rotate_phase(li2x, li2y, delta_2)?;
+    let (li3_in, li3_out) = rotate_phase(li3x, li3y, delta_3)?;
+    let (li4_in, li4_out) = rotate_phase(li4x, li4y, delta_4)?;
+    let (li5_in, li5_out) = rotate_phase(li5x, li5y, delta_5)?;
+    let (li6_in, li6_out) = rotate_phase(li6x, li6y, delta_6)?;
 
     let rotated_result: Vec<Vec<f64>> = vec![
         li1_in, li1_out, li2_in, li2_out, li3_in, li3_out, li4_in, li4_out, li5_in, li5_out,
@@ -271,6 +287,38 @@ mod tests {
     fn phase_analysis_rejects_incomplete_harmonic_columns() {
         let cfg = crate::test_support::test_config(vec![1], vec![2]);
         let error = phase_analysis(&cfg, &vec![vec![0.0]; 10]).unwrap_err();
-        assert!(error.to_string().contains("requires 12 lock-in columns"));
+        assert!(error.to_string().starts_with("length_mismatch:"));
+    }
+
+    #[test]
+    fn phase_analysis_rejects_extra_harmonic_columns() {
+        let cfg = crate::test_support::test_config(vec![1], vec![2]);
+        let error = phase_analysis(&cfg, &vec![vec![0.0]; 14]).unwrap_err();
+        assert!(error.to_string().starts_with("length_mismatch:"));
+    }
+
+    #[test]
+    fn phase_analysis_rejects_empty_columns() {
+        let cfg = crate::test_support::test_config(vec![1], vec![2]);
+        let error = phase_analysis(&cfg, &vec![Vec::new(); 12]).unwrap_err();
+        assert!(error.to_string().starts_with("empty_phase_column:"));
+    }
+
+    #[test]
+    fn phase_analysis_rejects_unequal_column_lengths() {
+        let cfg = crate::test_support::test_config(vec![1], vec![2]);
+        let mut columns = vec![vec![0.0; 2]; 12];
+        columns[7].pop();
+        let error = phase_analysis(&cfg, &columns).unwrap_err();
+        assert!(error.to_string().starts_with("length_mismatch:"));
+    }
+
+    #[test]
+    fn phase_analysis_rejects_non_finite_columns() {
+        let cfg = crate::test_support::test_config(vec![1], vec![2]);
+        let mut columns = vec![vec![0.0; 2]; 12];
+        columns[4][1] = f64::NAN;
+        let error = phase_analysis(&cfg, &columns).unwrap_err();
+        assert!(error.to_string().starts_with("non_finite_phase:"));
     }
 }

--- a/website/tests/waveform-analyzer.spec.ts
+++ b/website/tests/waveform-analyzer.spec.ts
@@ -1,6 +1,36 @@
 import AxeBuilder from '@axe-core/playwright';
 import { expect, test } from '@playwright/test';
 
+test('Wasm phase adapter preserves typed input errors', async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== 'desktop-chromium', 'single-browser Wasm boundary gate');
+  await page.goto('/pmoke/en/');
+  const messages = await page.evaluate(async () => {
+    const wasm = (await import('/pmoke/wasm/pmoke_web_wasm.js')) as unknown as {
+      default: () => Promise<unknown>;
+      rotate_phase_interleaved: (x: Float64Array, y: Float64Array, delta: number) => Float64Array;
+    };
+    await wasm.default();
+    const messageOf = (error: unknown) => (error instanceof Error ? error.message : String(error));
+    const capture = (operation: () => unknown) => {
+      try {
+        operation();
+        return 'no error';
+      } catch (error) {
+        return messageOf(error);
+      }
+    };
+    return {
+      length: capture(() => wasm.rotate_phase_interleaved(new Float64Array([1, 2]), new Float64Array([3]), 0.2)),
+      finite: capture(() => wasm.rotate_phase_interleaved(new Float64Array([Number.NaN]), new Float64Array([1]), 0.2)),
+      valid: Array.from(wasm.rotate_phase_interleaved(new Float64Array([1]), new Float64Array([0]), 0)),
+    };
+  });
+  expect(messages.length).toMatch(/^length_mismatch:/u);
+  expect(messages.finite).toMatch(/^non_finite_phase:/u);
+  expect(messages.valid).toEqual([1, 0]);
+  testInfo.annotations.push({ type: 'boundary', description: 'Wasm adapter returns stable phase error prefixes' });
+});
+
 for (const locale of ['en', 'ja'] as const) {
   test(`${locale} waveform analyzer completes native-parity demo`, async ({ page }, testInfo) => {
     await page.goto(`/pmoke/${locale}/docs/interactive/waveform-analyzer/`);


### PR DESCRIPTION
Refs #139

## Outcome
- Make shared phase rotation return checked results with stable `length_mismatch` and `non_finite_phase` codes.
- Enforce exactly six native lock-in x/y pairs before phase analysis and reject empty, unequal, or non-finite columns.
- Migrate native, WASM, and deterministic fixture consumers without changing valid numerical behavior.

## Validation
- `cargo fmt --all -- --check` passed.
- `cargo test --locked -p pmoke-analysis-core -p pmoke-web-wasm` passed.
- `cargo test --locked -p pmoke --lib phase::tests --no-default-features` passed (5 tests).

## Blockers and residual risk
- The default macOS pmoke test cannot link `-lgpib` in this workstation shell; the no-default-features native phase lane passes.
- The WASM adapter error-object test is target-gated because `JsError` cannot be constructed by host tests; browser/WASM boundary coverage is the next commit.

## Next work
- Add browser-level checks for shared WASM error prefixes and worker recovery.
- Run target checks, full relevant CI, and inspect the complete staged diff before merge.