### PR TITLE
chore(deps): migrate comfy-table to 8.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,9 +231,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "comfy-table"
-version = "7.2.2"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+checksum = "136c8c4c3823846e8ba6d4bda011b4e5d5827b8bb0ac26c31f9ab31abe9f54f2"
 dependencies = [
  "crossterm",
  "unicode-segmentation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ pyo3 = { version = "0.29.0", features = ["auto-initialize"] }
 numpy = "0.29.0"
 console = "0.16.4"
 indicatif = "0.18.6"
-comfy-table = "7.2.2"
+comfy-table = "8.0.0"
 ratatui = { version = "0.30.2", default-features = false, features = ["crossterm"] }
 crossterm = "0.29"
 clap_complete = "4.6.8"

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,7 +1,4 @@
-use comfy_table::{
-    Attribute, Cell, Color, ContentArrangement, Table, modifiers::UTF8_ROUND_CORNERS,
-    presets::UTF8_FULL,
-};
+use comfy_table::{Attribute, Cell, Color, ContentArrangement, Table, presets::UTF8_FULL};
 use console::{Term, style};
 use indicatif::{ProgressBar, ProgressStyle};
 use serde::{Deserialize, Serialize};
@@ -443,9 +440,9 @@ pub fn table(headers: &[&str], rows: Vec<Vec<String>>) -> Table {
 fn table_with_width(headers: &[&str], rows: Vec<Vec<String>>, width: u16) -> Table {
     let mut table = Table::new();
     table
-        .load_preset(UTF8_FULL)
-        .apply_modifier(UTF8_ROUND_CORNERS)
+        .load_style(UTF8_FULL.with_rounded_corners())
         .set_content_arrangement(ContentArrangement::Dynamic)
+        .set_truncation_indicator("...")
         .set_width(width.max(24));
     table.set_header(
         headers
@@ -577,5 +574,31 @@ mod tests {
             rendered.lines().all(|line| measure_text_width(line) <= 60),
             "{rendered}"
         );
+    }
+
+    #[test]
+    fn table_with_width_preserves_rounded_utf8_borders() {
+        let mut table = table_with_width(
+            &["Setting", "Value"],
+            vec![vec!["mode".to_string(), "first\nsecond".to_string()]],
+            40,
+        );
+        table.row_mut(0).unwrap().max_height(1);
+        let rendered = table.to_string();
+
+        assert!(
+            rendered
+                .lines()
+                .next()
+                .is_some_and(|line| line.starts_with('╭'))
+        );
+        assert!(
+            rendered
+                .lines()
+                .last()
+                .is_some_and(|line| line.starts_with('╰'))
+        );
+        assert!(rendered.contains("..."));
+        assert!(!rendered.contains('…'));
     }
 }


### PR DESCRIPTION
## Outcome

Upgrade the CLI table dependency to `comfy-table` 8.0.0 while preserving pmoke's rounded UTF-8 table borders and explicit `...` truncation behavior.

## Changed surface

- Update `Cargo.toml` and `Cargo.lock`.
- Migrate the removed v7 preset/modifier calls in `src/ui.rs` to the v8 `TableStyle` API.
- Add a focused regression test for rounded borders and truncation.

## Validation

- `nix develop -c cargo fmt --all -- --check`
- `nix develop -c cargo test --locked -p pmoke --all-targets --no-default-features` (395 library tests, 3 CLI tests)
- `nix develop -c cargo clippy --locked -p pmoke --all-targets --no-default-features -- -D warnings`
- `nix develop -c cargo check --locked --workspace --all-targets --no-default-features`
- `nix develop -c cargo check --locked -p pmoke --all-targets --all-features`

## Blockers and residual risk

- The local macOS environment cannot link the full workspace test lane because `libgpib` is unavailable; the feature-disabled pmoke test lane passes.
- `cargo-deny` is not present in the pinned local Nix shell; CI remains the source of truth for that gate.
- No schema, generated documentation, hardware behavior, or security boundary changes are included.

## Next work

Merge after the required CI checks pass on this exact commit and no blocking conversation remains.

Refs #145
