### PR TITLE
feat(website): replace signal-stage tabs with a process rail

### DIFF
--- a/website/app/[lang]/page.tsx
+++ b/website/app/[lang]/page.tsx
@@ -19,7 +19,8 @@ const copy = {
       label: 'Illustrative pulsed-field MOKE signal',
       description:
         'Illustrative pulsed-field MOKE pipeline: a unipolar field pulse defines a triggered measurement window; reference and Kerr-response signals are resolved into lock-in X/Y components, phase-rotated for each harmonic, and combined for Kerr-angle extraction.',
-      sequence: 'Pulsed-field MOKE signal sequence',
+      pipeline: 'SIGNAL PIPELINE',
+      sequence: 'Pulsed-field MOKE signal processing stages',
       fieldPulse: 'FIELD PULSE',
       triggeredWindow: 'TRIGGERED WINDOW',
       referenceResponse: 'REFERENCE + RESPONSE',
@@ -58,7 +59,8 @@ const copy = {
       label: 'パルス磁場MOKEの説明図',
       description:
         'パルス磁場MOKEの概念図。単極性の磁場パルスがトリガー窓を定め、参照信号とKerr応答をロックインX/Y成分へ変換する。高調波ごとの位相回転を経て、Kerr角を導出する。',
-      sequence: 'パルス磁場MOKEの信号シーケンス',
+      pipeline: '信号処理の流れ',
+      sequence: 'パルス磁場MOKEの信号処理ステップ',
       fieldPulse: '磁場パルス',
       triggeredWindow: 'トリガー窓',
       referenceResponse: '参照信号 + Kerr応答',

--- a/website/app/global.css
+++ b/website/app/global.css
@@ -1414,13 +1414,7 @@ html:not(.dark) .capability-grid p { color: #52615f; }
 
 @keyframes analyzer-pulse { 50% { opacity: 0.35; box-shadow: 0 0 0 7px color-mix(in srgb, var(--amber) 5%, transparent); } }
 
-@media (max-width: 900px) {
-  .hero-band { min-height: 820px; height: max(820px, calc(100svh - 96px)); max-height: 940px; }
-  .hero-copy { inset: 20rem 24px 0; justify-content: flex-end; padding-bottom: 1.75rem; }
-  .hero-copy-panel { width: 100%; padding-right: 1.1rem; }
-  .hero-copy h1 { font-size: 7rem; }
-  .hero-lead { width: min(680px, 100%); font-size: 2.15rem; }
-  .hero-description { width: min(680px, 100%); }
+@media (max-width: 959px) {
   .signal-sequence-shell { top: 1rem; left: 24px; right: 24px; }
   .signal-sequence { gap: 0.35rem; }
   .signal-step-label {
@@ -1443,6 +1437,15 @@ html:not(.dark) .capability-grid p { color: #52615f; }
     text-align: center;
     text-transform: uppercase;
   }
+}
+
+@media (max-width: 900px) {
+  .hero-band { min-height: 820px; height: max(820px, calc(100svh - 96px)); max-height: 940px; }
+  .hero-copy { inset: 20rem 24px 0; justify-content: flex-end; padding-bottom: 1.75rem; }
+  .hero-copy-panel { width: 100%; padding-right: 1.1rem; }
+  .hero-copy h1 { font-size: 7rem; }
+  .hero-lead { width: min(680px, 100%); font-size: 2.15rem; }
+  .hero-description { width: min(680px, 100%); }
   .analyzer-commandbar { grid-template-columns: 1fr auto; }
   .analyzer-status { grid-column: 1 / -1; grid-row: 2; justify-content: flex-start; }
   .analyzer-lower { grid-template-columns: 1fr; }

--- a/website/app/global.css
+++ b/website/app/global.css
@@ -412,57 +412,104 @@ button:focus-visible {
   display: block;
 }
 
-.signal-sequence {
+.signal-sequence-shell {
   position: absolute;
   top: 1.25rem;
   left: max(24px, calc((100vw - 1440px) / 2));
   right: max(24px, calc((100vw - 1440px) / 2));
   z-index: 2;
+}
+
+.signal-sequence-title {
+  margin: 0 0 0.7rem;
+  color: #829391;
+  font: 700 0.57rem/1 var(--font-mono), monospace;
+  letter-spacing: 0.12em;
+}
+
+.signal-sequence {
+  position: relative;
   display: grid;
   grid-template-columns: repeat(5, minmax(0, 1fr));
   gap: 0.55rem;
   margin: 0;
   padding: 0;
   list-style: none;
-  counter-reset: signal-stage;
   pointer-events: none;
+}
+
+.signal-sequence::before {
+  content: '';
+  position: absolute;
+  top: 0.82rem;
+  right: 10%;
+  left: 10%;
+  z-index: 0;
+  height: 1px;
+  background: rgba(147, 161, 165, 0.42);
 }
 
 .signal-sequence li {
   position: relative;
+  z-index: 1;
   min-width: 0;
-  min-height: 39px;
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 0.45rem;
-  padding: 0.42rem 0.55rem;
-  overflow-wrap: anywhere;
-  border: 1px solid transparent;
-  border-top-color: rgba(147, 161, 165, 0.46);
-  background: linear-gradient(90deg, rgba(16, 21, 23, 0.64), rgba(16, 21, 23, 0.25));
+  gap: 0.5rem;
+  padding: 0;
   color: #aebcba;
-  font: 650 0.58rem/1.25 var(--font-mono), monospace;
-  letter-spacing: 0.025em;
+  text-align: center;
 }
 
-.signal-sequence li::before {
-  counter-increment: signal-stage;
-  content: counter(signal-stage, decimal-leading-zero);
-  flex: none;
-  color: #647677;
-  font-size: 0.52rem;
+.signal-step-marker {
+  display: grid;
+  width: 1.65rem;
+  height: 1.65rem;
+  place-items: center;
+  border: 1px solid rgba(147, 161, 165, 0.58);
+  border-radius: 50%;
+  background: rgba(16, 21, 23, 0.94);
+  color: #71817f;
+  font: 650 0.54rem/1 var(--font-mono), monospace;
   letter-spacing: 0;
 }
 
-.signal-stage[data-sequence-stage='field-pulse'] .signal-sequence [data-step='field-pulse'],
-.signal-stage[data-sequence-stage='waveforms'] .signal-sequence [data-step='waveforms'],
-.signal-stage[data-sequence-stage='lock-in'] .signal-sequence [data-step='lock-in'],
-.signal-stage[data-sequence-stage='rotate-phase'] .signal-sequence [data-step='rotate-phase'],
-.signal-stage[data-sequence-stage='kerr-angle'] .signal-sequence [data-step='kerr-angle'] {
-  border-top-color: var(--cyan);
+.signal-step-label {
+  max-width: 16ch;
+  color: #81908e;
+  font: 650 0.55rem/1.25 var(--font-mono), monospace;
+  letter-spacing: 0.025em;
+  text-align: center;
+  text-wrap: balance;
+}
+
+.signal-sequence li[data-current='true'] .signal-step-marker {
+  border-color: var(--cyan);
+  background: var(--cyan);
+  color: var(--ink);
+  box-shadow: 0 0 0 5px rgba(22, 217, 209, 0.1), 0 0 20px rgba(22, 217, 209, 0.2);
+  animation: signal-node-pulse 2.2s ease-in-out infinite;
+}
+
+.signal-sequence li[data-current='true'] .signal-step-label {
   color: #effffd;
-  background: linear-gradient(90deg, rgba(22, 217, 209, 0.16), rgba(22, 217, 209, 0.03));
-  box-shadow: 0 -1px 0 rgba(22, 217, 209, 0.24), 0 8px 24px rgba(22, 217, 209, 0.05);
+}
+
+.signal-current-stage {
+  display: none;
+}
+
+@keyframes signal-node-pulse {
+  50% {
+    box-shadow: 0 0 0 8px rgba(22, 217, 209, 0.04), 0 0 24px rgba(22, 217, 209, 0.28);
+  }
+}
+
+.signal-stage[data-motion='paused'] .signal-sequence li[data-current='true'] .signal-step-marker,
+.signal-stage[data-motion='reduced'] .signal-sequence li[data-current='true'] .signal-step-marker,
+.signal-stage[data-wasm='fallback'] .signal-sequence li[data-current='true'] .signal-step-marker {
+  animation: none;
 }
 
 .signal-description {
@@ -683,18 +730,13 @@ html:not(.dark) .signal-stage {
 }
 html:not(.dark) .signal-stage::after { background: rgba(242, 245, 243, 0.24); }
 html:not(.dark) .signal-hud { color: #536563; }
-html:not(.dark) .signal-sequence li { border-color: transparent; border-top-color: rgba(68, 87, 90, 0.48); background: linear-gradient(90deg, rgba(238, 243, 241, 0.88), rgba(238, 243, 241, 0.45)); color: #44575a; }
-html:not(.dark) .signal-sequence li::before { color: #71817f; }
-html:not(.dark) .signal-stage[data-sequence-stage='field-pulse'] .signal-sequence [data-step='field-pulse'],
-html:not(.dark) .signal-stage[data-sequence-stage='waveforms'] .signal-sequence [data-step='waveforms'],
-html:not(.dark) .signal-stage[data-sequence-stage='lock-in'] .signal-sequence [data-step='lock-in'],
-html:not(.dark) .signal-stage[data-sequence-stage='rotate-phase'] .signal-sequence [data-step='rotate-phase'],
-html:not(.dark) .signal-stage[data-sequence-stage='kerr-angle'] .signal-sequence [data-step='kerr-angle'] { color: #164b4a; }
-html:not(.dark) .signal-stage[data-sequence-stage='field-pulse'] .signal-sequence [data-step='field-pulse'],
-html:not(.dark) .signal-stage[data-sequence-stage='waveforms'] .signal-sequence [data-step='waveforms'],
-html:not(.dark) .signal-stage[data-sequence-stage='lock-in'] .signal-sequence [data-step='lock-in'],
-html:not(.dark) .signal-stage[data-sequence-stage='rotate-phase'] .signal-sequence [data-step='rotate-phase'],
-html:not(.dark) .signal-stage[data-sequence-stage='kerr-angle'] .signal-sequence [data-step='kerr-angle'] { border-top-color: #087b7b; background: linear-gradient(90deg, rgba(8, 123, 123, 0.14), rgba(8, 123, 123, 0.03)); }
+html:not(.dark) .signal-sequence-title { color: #637575; }
+html:not(.dark) .signal-sequence::before { background: rgba(68, 87, 90, 0.42); }
+html:not(.dark) .signal-step-marker { border-color: rgba(68, 87, 90, 0.58); background: rgba(238, 243, 241, 0.94); color: #71817f; }
+html:not(.dark) .signal-step-label { color: #637575; }
+html:not(.dark) .signal-current-stage { color: #164b4a; }
+html:not(.dark) .signal-sequence li[data-current='true'] .signal-step-marker { border-color: #087b7b; background: #087b7b; color: #f5ffff; box-shadow: 0 0 0 5px rgba(8, 123, 123, 0.1), 0 0 20px rgba(8, 123, 123, 0.18); }
+html:not(.dark) .signal-sequence li[data-current='true'] .signal-step-label { color: #164b4a; }
 html:not(.dark) .signal-control { border-color: #82908e; background: rgba(238, 243, 241, 0.86); color: #172023; }
 html:not(.dark) .signal-control:hover,
 html:not(.dark) .signal-control:focus-visible { color: #164b4a; }
@@ -1379,6 +1421,28 @@ html:not(.dark) .capability-grid p { color: #52615f; }
   .hero-copy h1 { font-size: 7rem; }
   .hero-lead { width: min(680px, 100%); font-size: 2.15rem; }
   .hero-description { width: min(680px, 100%); }
+  .signal-sequence-shell { top: 1rem; left: 24px; right: 24px; }
+  .signal-sequence { gap: 0.35rem; }
+  .signal-step-label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+  .signal-current-stage {
+    display: block;
+    margin: 0.7rem 0 0;
+    color: #effffd;
+    font: 650 0.62rem/1.3 var(--font-mono), monospace;
+    letter-spacing: 0.04em;
+    text-align: center;
+    text-transform: uppercase;
+  }
   .analyzer-commandbar { grid-template-columns: 1fr auto; }
   .analyzer-status { grid-column: 1 / -1; grid-row: 2; justify-content: flex-start; }
   .analyzer-lower { grid-template-columns: 1fr; }
@@ -1408,9 +1472,12 @@ html:not(.dark) .capability-grid p { color: #52615f; }
   .hero-lead { margin-top: 1.1rem; font-size: 1.55rem; }
   .hero-description { margin-top: 0.7rem; font-size: 0.9rem; line-height: 1.48; }
   .hero-actions { margin-top: 1.1rem; }
-  .signal-sequence { top: 0.9rem; left: 14px; right: 14px; grid-template-columns: repeat(5, minmax(0, 1fr)); gap: 0.22rem; }
-  .signal-sequence li { min-height: 43px; gap: 0.2rem; padding: 0.32rem 0.25rem; font-size: 0.47rem; line-height: 1.2; }
-  .signal-sequence li::before { display: none; }
+  .signal-sequence-shell { top: 0.9rem; left: 14px; right: 14px; }
+  .signal-sequence-title { margin-bottom: 0.6rem; font-size: 0.52rem; }
+  .signal-sequence { gap: 0.22rem; }
+  .signal-step-marker { width: 1.45rem; height: 1.45rem; font-size: 0.5rem; }
+  .signal-sequence::before { top: 0.72rem; }
+  .signal-current-stage { margin-top: 0.6rem; font-size: 0.57rem; }
   .signal-controls { top: 5.7rem; right: 14px; }
   .signal-hud { left: 14px; right: auto; bottom: 18px; }
   .signal-hud span:not(.signal-status) { display: none; }
@@ -1449,4 +1516,5 @@ html:not(.dark) .capability-grid p { color: #52615f; }
 
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after { scroll-behavior: auto !important; animation-duration: 0.01ms !important; }
+  .signal-sequence li[data-current='true'] .signal-step-marker { animation: none; }
 }

--- a/website/components/signal-hero.tsx
+++ b/website/components/signal-hero.tsx
@@ -16,6 +16,7 @@ export type SignalSequenceStage = 'field-pulse' | 'waveforms' | 'lock-in' | 'rot
 export type SignalHeroLabels = {
   label: string;
   description: string;
+  pipeline: string;
   sequence: string;
   fieldPulse: string;
   triggeredWindow: string;
@@ -246,6 +247,34 @@ export function SignalHero({ labels }: { labels: SignalHeroLabels }) {
     let accumulatedTime = 0;
     let lastTimestamp: number | null = null;
 
+    const stageLabels: Record<SignalSequenceStage, string> = {
+      'field-pulse': labels.fieldPulse,
+      waveforms: labels.referenceResponse,
+      'lock-in': labels.lockIn,
+      'rotate-phase': labels.rotatePhase,
+      'kerr-angle': labels.kerrAngle,
+    };
+    const sequenceItems = Array.from(
+      container.querySelectorAll<HTMLElement>('.signal-sequence [data-step]'),
+    );
+    const currentStageLabel = container.querySelector<HTMLElement>('.signal-current-stage');
+
+    const syncSequenceStage = (nextStage: SignalSequenceStage) => {
+      container.dataset.sequenceStage = nextStage;
+      for (const item of sequenceItems) {
+        const isCurrent = item.dataset.step === nextStage;
+        item.dataset.current = isCurrent ? 'true' : 'false';
+        if (isCurrent) {
+          item.setAttribute('aria-current', 'step');
+        } else {
+          item.removeAttribute('aria-current');
+        }
+      }
+      if (currentStageLabel && currentStageLabel.textContent !== stageLabels[nextStage]) {
+        currentStageLabel.textContent = stageLabels[nextStage];
+      }
+    };
+
     const getTargetDpr = () => Math.min(window.devicePixelRatio || 1, 2);
     let currentDpr = getTargetDpr();
 
@@ -276,7 +305,7 @@ export function SignalHero({ labels }: { labels: SignalHeroLabels }) {
       const sequenceProgress = complete ? 1 : normalize(sweepOffset);
       const sequenceStage = sequenceStageForProgress(sequenceProgress);
       if (container.dataset.sequenceStage !== sequenceStage) {
-        container.dataset.sequenceStage = sequenceStage;
+        syncSequenceStage(sequenceStage);
       }
 
       const renderedPoints = drawSignals(
@@ -455,13 +484,32 @@ export function SignalHero({ labels }: { labels: SignalHeroLabels }) {
         aria-describedby="signal-description"
         role="img"
       />
-      <ol className="signal-sequence" aria-label={labels.sequence}>
-        <li data-step="field-pulse">{labels.fieldPulse}</li>
-        <li data-step="waveforms">{labels.referenceResponse}</li>
-        <li data-step="lock-in">{labels.lockIn}</li>
-        <li data-step="rotate-phase">{labels.rotatePhase}</li>
-        <li data-step="kerr-angle">{labels.kerrAngle}</li>
-      </ol>
+      <div className="signal-sequence-shell">
+        <p className="signal-sequence-title">{labels.pipeline}</p>
+        <ol className="signal-sequence" aria-label={labels.sequence}>
+          <li data-step="field-pulse" data-current="true" aria-current="step">
+            <span className="signal-step-marker" aria-hidden="true">01</span>
+            <span className="signal-step-label">{labels.fieldPulse}</span>
+          </li>
+          <li data-step="waveforms" data-current="false">
+            <span className="signal-step-marker" aria-hidden="true">02</span>
+            <span className="signal-step-label">{labels.referenceResponse}</span>
+          </li>
+          <li data-step="lock-in" data-current="false">
+            <span className="signal-step-marker" aria-hidden="true">03</span>
+            <span className="signal-step-label">{labels.lockIn}</span>
+          </li>
+          <li data-step="rotate-phase" data-current="false">
+            <span className="signal-step-marker" aria-hidden="true">04</span>
+            <span className="signal-step-label">{labels.rotatePhase}</span>
+          </li>
+          <li data-step="kerr-angle" data-current="false">
+            <span className="signal-step-marker" aria-hidden="true">05</span>
+            <span className="signal-step-label">{labels.kerrAngle}</span>
+          </li>
+        </ol>
+        <p className="signal-current-stage" aria-hidden="true">{labels.fieldPulse}</p>
+      </div>
       <p id="signal-description" className="signal-description">{labels.description}</p>
       <div className="signal-hud">
         <span className="signal-status" role="status" aria-live="polite">

--- a/website/tests/foundation.spec.ts
+++ b/website/tests/foundation.spec.ts
@@ -147,7 +147,10 @@ test('documentation remains readable without JavaScript', async ({ browser }, te
   const page = await context.newPage();
   await page.goto('http://127.0.0.1:4173/pmoke/ja/');
   await expect(page.getByRole('heading', { level: 1, name: 'pmoke' })).toBeVisible();
-  await expect(page.locator('.signal-sequence')).toContainText('磁場パルス');
+  await expect(page.locator('.signal-sequence-title')).toHaveText('信号処理の流れ');
+  await expect(page.locator('.signal-sequence')).toHaveAttribute('aria-label', 'パルス磁場MOKEの信号処理ステップ');
+  await expect(page.locator('.signal-sequence .signal-step-label').first()).toHaveText('磁場パルス');
+  await expect(page.locator('.signal-current-stage')).toHaveText('磁場パルス');
   await expect(page.locator('#signal-description')).toContainText('パルス磁場MOKEの概念図');
   await page.goto('http://127.0.0.1:4173/pmoke/ja/docs/quickstart/');
   await expect(page.getByRole('heading', { level: 1, name: 'クイックスタート' })).toBeVisible();
@@ -223,10 +226,11 @@ test('signal canvas sweeps continuously when active and pauses on reduced motion
   await page.waitForTimeout(300);
   const secondStatic = await page.locator('.signal-stage canvas').evaluate((canvas: HTMLCanvasElement) => canvas.toDataURL());
   expect(secondStatic).toBe(firstStatic);
+  await expect(page.locator('.signal-sequence li[aria-current="step"]')).toHaveAttribute('data-step', 'kerr-angle');
   await expect(page.getByRole('button', { name: 'Static view (reduced motion)' })).toBeDisabled();
 });
 
-test('signal hero exposes localized sequence semantics and a user pause', async ({ page }, testInfo) => {
+test('signal hero exposes localized process semantics and a user pause', async ({ page }, testInfo) => {
   test.skip(testInfo.project.name !== 'desktop-chromium', 'single-browser signal semantics contract');
 
   await page.emulateMedia({ reducedMotion: 'no-preference' });
@@ -253,7 +257,14 @@ test('signal hero exposes localized sequence semantics and a user pause', async 
     );
     await expect(canvas).toHaveAttribute('aria-describedby', 'signal-description');
     await expect(page.locator('#signal-description')).toContainText(description);
-    await expect(stage.locator('.signal-sequence li')).toHaveText(labels);
+    await expect(stage.locator('.signal-sequence-title')).toHaveText(
+      locale === 'en' ? 'SIGNAL PIPELINE' : '信号処理の流れ',
+    );
+    await expect(stage.locator('.signal-sequence')).toHaveAttribute(
+      'aria-label',
+      locale === 'en' ? 'Pulsed-field MOKE signal processing stages' : 'パルス磁場MOKEの信号処理ステップ',
+    );
+    await expect(stage.locator('.signal-sequence .signal-step-label')).toHaveText(labels);
     expect(await stage.locator('.signal-sequence li').evaluateAll((items) => items.map((item) => item.dataset.step))).toEqual([
       'field-pulse',
       'waveforms',
@@ -261,6 +272,23 @@ test('signal hero exposes localized sequence semantics and a user pause', async 
       'rotate-phase',
       'kerr-angle',
     ]);
+    const readRailState = () => stage.evaluate((element) => {
+      const active = [...element.querySelectorAll<HTMLElement>('.signal-sequence li[aria-current="step"]')]
+        .map((item) => item.dataset.step);
+      return {
+        stage: element.dataset.sequenceStage,
+        active,
+        focusable: element.querySelectorAll('.signal-sequence a, .signal-sequence button, .signal-sequence [role="tab"], .signal-sequence [tabindex]').length,
+        liveRegions: element.querySelectorAll('.signal-sequence [aria-live]').length,
+      };
+    });
+    const railState = await readRailState();
+    expect(railState.active).toEqual([railState.stage]);
+    expect(railState.focusable).toBe(0);
+    expect(railState.liveRegions).toBe(0);
+    await expect.poll(async () => (await readRailState()).stage, { timeout: 7_000 }).not.toBe(railState.stage);
+    const progressedRailState = await readRailState();
+    expect(progressedRailState.active).toEqual([progressedRailState.stage]);
     await expect(page.getByText(locale === 'en' ? 'ACQUISITION WINDOW' : '取得窓', { exact: true })).toHaveCount(0);
     await expect(page.locator('#signal-description')).toContainText(locale === 'en' ? 'triggered measurement window' : 'トリガー窓');
     expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBeTruthy();
@@ -279,10 +307,12 @@ test('signal hero exposes localized sequence semantics and a user pause', async 
       await control.click();
       await expect(stage).toHaveAttribute('data-motion', 'paused');
       await expect(stage).toHaveAttribute('data-user-paused', 'true');
+      const pausedRailState = await readRailState();
       const firstPaused = await canvas.evaluate((element: HTMLCanvasElement) => element.toDataURL());
       await page.waitForTimeout(300);
       const secondPaused = await canvas.evaluate((element: HTMLCanvasElement) => element.toDataURL());
       expect(secondPaused).toBe(firstPaused);
+      expect(await readRailState()).toEqual(pausedRailState);
 
       await page.evaluate(() => document.dispatchEvent(new Event('visibilitychange')));
       await expect(control).toHaveAttribute('aria-pressed', 'true');
@@ -307,7 +337,29 @@ test('signal hero reports an informative static fallback when Wasm is unavailabl
   await expect(stage.locator('.signal-status')).toHaveText('静的フォールバック');
   await expect(page.getByRole('button', { name: '静的フォールバック（WASM利用不可）' })).toBeDisabled();
   await expect(page.getByText('WASM ONLINE', { exact: true })).toHaveCount(0);
-  await expect(stage.locator('.signal-sequence li')).toHaveText(['磁場パルス', '参照信号 + Kerr応答', 'ロックイン X / Y', '位相回転', 'Kerr角']);
+  await expect(stage.locator('.signal-sequence .signal-step-label')).toHaveText(['磁場パルス', '参照信号 + Kerr応答', 'ロックイン X / Y', '位相回転', 'Kerr角']);
+  await expect(stage.locator('.signal-sequence li[aria-current="step"]')).toHaveAttribute('data-step', 'kerr-angle');
+  await expect(stage.locator('.signal-current-stage')).toHaveText('Kerr角');
+});
+
+test('signal process rail stays compact and non-interactive below desktop width', async ({ page }, testInfo) => {
+  test.skip(!['tablet-chromium', 'mobile-chromium'].includes(testInfo.project.name), 'compact process rail gate');
+
+  for (const locale of ['en', 'ja'] as const) {
+    await page.goto(`/pmoke/${locale}/`);
+    const stage = page.locator('.signal-stage');
+    await expect(stage).toHaveAttribute('data-wasm', 'ready', { timeout: 15_000 });
+    await expect(stage.locator('.signal-current-stage')).toBeVisible();
+    const compactLabel = await stage.locator('.signal-sequence .signal-step-label').first().evaluate((element) => {
+      const style = getComputedStyle(element);
+      const rect = element.getBoundingClientRect();
+      return { position: style.position, width: rect.width, height: rect.height, clip: style.clip };
+    });
+    expect(compactLabel).toMatchObject({ position: 'absolute', width: 1, height: 1 });
+    expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBeTruthy();
+    expect(await stage.locator('.signal-sequence li[aria-current="step"]').count()).toBe(1);
+    expect(await stage.locator('.signal-sequence a, .signal-sequence button, .signal-sequence [role="tab"], .signal-sequence [tabindex]').count()).toBe(0);
+  }
 });
 
 test('signal renderer survives reload and Wasm readiness without restarting', async ({ page }, testInfo) => {

--- a/website/tests/foundation.spec.ts
+++ b/website/tests/foundation.spec.ts
@@ -343,7 +343,11 @@ test('signal hero reports an informative static fallback when Wasm is unavailabl
 });
 
 test('signal process rail stays compact and non-interactive below desktop width', async ({ page }, testInfo) => {
-  test.skip(!['tablet-chromium', 'mobile-chromium'].includes(testInfo.project.name), 'compact process rail gate');
+  test.skip(!['desktop-chromium', 'tablet-chromium', 'mobile-chromium'].includes(testInfo.project.name), 'compact process rail gate');
+
+  if (testInfo.project.name === 'desktop-chromium') {
+    await page.setViewportSize({ width: 959, height: 900 });
+  }
 
   for (const locale of ['en', 'ja'] as const) {
     await page.goto(`/pmoke/${locale}/`);


### PR DESCRIPTION
Refs #149

## Scope / outcome

- Replaced the homepage's tab-like `01`–`05` strip with a non-interactive
  numbered signal process rail.
- Kept the existing five stage IDs and canvas animation contract.
- Added synchronized `aria-current="step"` state and a compact current-stage
  label below 960px, including the 959px breakpoint boundary.
- Preserved English/Japanese parity, static export, no-JavaScript content, and
  `/pmoke/` routing.

## Validation

- Nix-shell `pnpm lint`, `pnpm types:check`, and `pnpm test:signal`: passed.
- `pnpm run build:site`: passed.
- Signal-focused Playwright tests across desktop, wide, tablet, and mobile:
  8 passed; 16 skipped by the existing project-specific gates.
- Visual checkpoint: `/pmoke/en/` and `/pmoke/ja/` at wide, tablet, and phone
  viewports; dark/light themes and reduced motion checked; no browser console
  errors or horizontal overflow.

## Blocker / residual risk

- No known blocker.
- The macOS Nix build emits the existing deployment-target linker warning while
  rebuilding the unchanged browser WASM package; the build succeeds.
- Full release CI remains the final cross-browser, accessibility, Lighthouse,
  and static-deployment gate.

## Next work

- Review the exact PR head and wait for required CI checks.
- Merge after the acceptance criteria and deployment verification pass.
