### PR TITLE
docs(release): finalize pmoke v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.4.0 — 2026-08-12
+
 ### Breaking changes
 
 - The default pmoke build now enables direct TCP/IP, direct GPIB/VISA, and


### PR DESCRIPTION
Refs #159

## Outcome

- Finalize the current 0.4.0 development changelog as `v0.4.0 — 2026-08-12`.
- Preserve the already aligned Cargo package, Cargo.lock, generated references, config schema v5, runtime behavior, and private website package version.
- Leave correction of the existing v1.0.0 Draft release metadata for the post-merge release handoff.

## Scope

This PR contains only the changelog release cut. It does not change Rust, WASM, Python, website behavior, dependencies, schema, CI permissions, or release publication.

## Review 1 — design and compatibility

- The latest public release is v0.3.0 and the product manifests/generated metadata are already 0.4.0.
- The accumulated breaking changes since v0.3.0 are therefore correctly released as 0.4.0 under the project 0.x SemVer policy.
- Configuration schema v5, migration behavior, artifact formats, public routes, and security boundaries are unchanged.
- Rollback is a single changelog commit.

## Review 2 — staged handoff

- Staged diff contains only `CHANGELOG.md`.
- `git diff --cached --check` passed.
- No generated output, dependency lockfile, credential, private path, raw measurement, or build product is included.

## Validation

Already passed on the exact parent main revision:

- Nix flake check
- Rust format, 395 pmoke tests, core/WASM tests, clippy, and generated-reference drift
- Website `pnpm check`, frozen dependency restore, license policy, and production build
- Main CI, CodeQL, dependency/secret policy, browser/accessibility/visual, Lighthouse, GitHub Pages deployment, and post-deploy verification

## Next work

After this PR merges, correct the existing GitHub Draft release metadata to v0.4.0, verify the merged release artifacts, and close #159.