### PR TITLE
docs(guidance): document website visual sign-off workflow

### DIFF
--- a/.agents/skills/pmoke-maintenance/SKILL.md
+++ b/.agents/skills/pmoke-maintenance/SKILL.md
@@ -208,6 +208,15 @@ GUI/systemd/USB-IP integration merely to run `build`, `check`, or `test`; use a
 Nix-provided browser when visual or browser validation is required and report
 its absence as an environment limitation.
 
+When Playwright MCP is available in the agent session, use it for the
+interactive website checkpoint described by `$pmoke-website`: start the local
+site from `nix develop`, inspect both locale roots, resize through the required
+viewports, use accessibility snapshots and keyboard actions, and inspect
+console errors. MCP is an existing browser-control channel, not a package
+installer or a substitute for `pnpm check`, `pnpm test:e2e`, CI, or Lighthouse.
+Keep screenshots and console captures out of the repository unless a reviewed,
+redacted visual artifact is part of the project contract.
+
 Keep machine-test results private until redacted. A public handoff should
 include only the target role, commit, feature profile, toolchain source,
 commands, pass/fail result, and environment limitation; omit endpoints,
@@ -291,6 +300,11 @@ changes, run the cross-browser release project and Lighthouse gate as well.
 Preserve no-JavaScript readability, keyboard/accessibility behavior, search
 fallbacks, worker failure recovery, bounded input limits, AI-resource
 contracts, and English/Japanese parity.
+
+For interactive UI work, follow the Playwright MCP checkpoint in
+`$pmoke-website` when MCP is available. Treat its route/viewport/theme evidence
+as Review 1 input, then run the reproducible command and CI-equivalent gates
+before handoff.
 
 ### Security and benchmark lane
 

--- a/.agents/skills/pmoke-maintenance/SKILL.md
+++ b/.agents/skills/pmoke-maintenance/SKILL.md
@@ -38,11 +38,21 @@ compatibility, or security contract. Keep the public work-item split explicit:
 - Use one GitHub Issue for each durable user-facing goal. The Issue should state
   the purpose, scope, non-goals, acceptance criteria, compatibility impact,
   security impact, design decision, and validation plan.
-- When implementation starts, create a normal PR linked with `Refs #N` and
+- When public implementation starts, create a normal PR linked with `Refs #N` and
   keep it open for review from the beginning; do not use a Draft PR phase. Keep
   the PR description limited to the current outcome, changed surface,
   validation evidence, blockers, residual risks, and next work; do not write a
   chronological diary.
+- For website UI slices whose layout, typography, animation, copy, or
+  interaction still needs user direction, apply the `$pmoke-website` visual
+  sign-off gate before the first commit or push: keep the work local, run the
+  Nix-managed `pnpm run build:dev` checkpoint with Playwright MCP when
+  available (otherwise use the Nix-provided browser/CLI and report the
+  limitation), and obtain explicit visual sign-off. After approval, perform
+  both reviews, commit the cohesive slice, push, and open a normal PR. This is
+  not a Draft PR and is not browser/account authentication; security,
+  CI/release, non-visual correctness, and generated-contract changes use the
+  ordinary workflow.
 - Review 1 records the Issue/design/API/security decision. Review 2 records the
   complete staged diff, tests, and generated artifacts. Merge only after the
   acceptance criteria and validation evidence are complete, the current head

--- a/.agents/skills/pmoke-website/SKILL.md
+++ b/.agents/skills/pmoke-website/SKILL.md
@@ -54,6 +54,32 @@ the CI browser/accessibility/visual and Lighthouse gates. If MCP is unavailable,
 use the Nix-provided browser and the repository's Playwright CLI checks, and
 report the limitation.
 
+## Visual sign-off gate
+
+For a UI slice whose layout, typography, animation, copy, or interaction is
+still a product choice, keep the implementation on a private local topic
+branch until the user approves the rendered direction. This is a temporary
+pre-publication checkpoint, not a Draft PR:
+
+1. Define the durable goal and acceptance criteria in the Issue, then restore
+   dependencies and start `pnpm run build:dev` from the Nix shell.
+2. Review the changed route with the Playwright MCP checkpoint: inspect both
+   locales, relevant wide/narrow/phone viewports, keyboard focus, reduced
+   motion, and console errors. Keep captures and logs local unless a reviewed
+   redacted artifact is explicitly required.
+3. Present concise route, locale, viewport, theme, and dev/export evidence and
+   request explicit user visual sign-off. A successful build, browser snapshot,
+   or account login is not the sign-off.
+4. If the direction is rejected, iterate locally without committing or
+   pushing the unapproved UI. After approval, perform Review 1 and Review 2,
+   create the cohesive commit, push, and open the normal linked PR. Run the
+   required checks and CI against that exact head.
+
+This gate is limited to visual/product decisions. Security fixes, CI or
+release blockers, non-visual correctness fixes, generated contract changes,
+and changes where delaying public review would create material risk follow the
+ordinary Issue and normal PR workflow.
+
 ## Product map
 
 - `website/app/`, `components/`, and `styles/`: Next.js routes and UI.
@@ -68,12 +94,13 @@ Preserve the `/pmoke/` base path, static export behavior, English/Japanese
 parity, no-JavaScript readability, and bounded worker/WASM failure recovery.
 Treat generated references and release metadata as owned by their generators.
 For a durable website goal, use the repository's public Issue → normal PR
-workflow. Open the PR when implementation starts and keep it available for
-review; do not use a Draft PR phase. Keep the Issue's acceptance,
-compatibility, and security decisions separate from the PR's current
-validation state. Put UI evidence in the Issue or PR with route, locale,
-viewport, theme, and dev/export context; do not add an unredacted screenshot,
-recording, log, endpoint, or personal path to the repository.
+workflow. A UI/product-choice slice follows the visual sign-off gate above
+before its first commit or push; after sign-off, open the normal PR promptly
+and keep it available for review. Do not use a Draft PR phase. Keep the
+Issue's acceptance, compatibility, and security decisions separate from the
+PR's current validation state. Put UI evidence in the Issue or PR with route,
+locale, viewport, theme, and dev/export context; do not add an unredacted
+screenshot, recording, log, endpoint, or personal path to the repository.
 
 ## Long website changes
 
@@ -94,13 +121,15 @@ on behavior and rendered output, stage and perform Review 2 on the complete
 diff, then commit. If a fix changes the reviewed surface, repeat both reviews
 and the affected checks.
 
-For UI slices, use `pnpm run build:dev` as the iterative visual checkpoint and
-record the route, locale, viewport, theme, and dev/export context. Push and
-open the normal PR only when external handoff is authorized; merge only after
-the exact head has passing required and relevant CI (including browser,
-accessibility, visual, and Lighthouse gates when applicable), resolved
-conversations, and no blocking review. A single maintainer records Review 1
-and Review 2 explicitly rather than fabricating a second approval.
+For UI slices, use `pnpm run build:dev` and the visual sign-off gate before the
+first commit or push when the product direction is still under discussion.
+Record the route, locale, viewport, theme, and dev/export context. After
+explicit sign-off, perform Review 1 and Review 2, then push and open the
+normal PR; merge only after the exact head has passing required and relevant CI
+(including browser, accessibility, visual, and Lighthouse gates when
+applicable), resolved conversations, and no blocking review. A single
+maintainer records Review 1 and Review 2 explicitly rather than fabricating a
+second approval.
 
 ## UI-first workflow
 
@@ -140,10 +169,12 @@ and Review 2 explicitly rather than fabricating a second approval.
    errors. If no browser is available, report the live URL and limitation
    instead of claiming a visual pass.
 
-4. Stop at a visual checkpoint when layout, typography, interaction, or visual
-   hierarchy is a matter of product choice. Show the route/viewport evidence
-   and obtain the user's direction before making a broad design change. Do not
-   silently turn a typecheck or static build into a visual approval.
+4. Stop at a visual checkpoint when layout, typography, animation, copy,
+   interaction, or visual hierarchy is a matter of product choice. Show the
+   route/viewport evidence and obtain explicit user visual sign-off before
+   committing or pushing the slice. If the direction is not approved, iterate
+   locally. Do not silently turn a typecheck, static build, browser snapshot,
+   or account login into visual approval.
 
 5. Before handoff, run the smallest relevant production and contract checks:
 
@@ -183,9 +214,11 @@ and Review 2 explicitly rather than fabricating a second approval.
 
 ## Public progress and handoff
 
-Use a GitHub Issue for the durable user-facing goal, a normal PR opened at the
-start of active work, and the PR description for a concise checklist of scope,
-visible outcome, validation, screenshots, and blockers. Keep private
+Use a GitHub Issue for the durable user-facing goal, then open a normal PR when
+public implementation starts. For UI/product-choice slices, public
+implementation starts after the visual sign-off gate; the local visual review
+is not a Draft PR phase. Keep the PR description as a concise checklist of
+scope, visible outcome, validation, screenshots, and blockers. Keep private
 deliberation and temporary notes out of tracked files. Use README/docs for
 stable instructions and a changelog for released user-visible changes; do not
 add a chronological public work diary unless the project explicitly wants one.

--- a/.agents/skills/pmoke-website/SKILL.md
+++ b/.agents/skills/pmoke-website/SKILL.md
@@ -23,6 +23,37 @@ USB/IP integration. Do not enable or mutate those capabilities just to run a
 site build; use an already provisioned Nix browser for visual checks and report
 its absence instead of downloading one through a package manager.
 
+## Playwright MCP UI checkpoint
+
+When Playwright MCP is available in the agent session, prefer it for the
+interactive visual and accessibility checkpoint. Start the application with
+`pnpm run build:dev` from the Nix shell and keep the owned development server
+running. Then use the MCP browser tools to:
+
+1. Navigate to `http://localhost:3000/pmoke/en/` and
+   `http://localhost:3000/pmoke/ja/` with `browser_navigate`.
+2. Use `browser_snapshot` to inspect landmarks, headings, accessible names,
+   focusable controls, and the no-JavaScript-readable structure before using
+   element actions.
+3. Use `browser_resize` for a wide desktop, narrow/tablet, and phone viewport;
+   use `browser_take_screenshot` only when visual evidence is useful.
+4. Exercise keyboard focus with `browser_press_key`, check light/dark and
+   reduced-motion states, and inspect `browser_console_messages` at error and
+   warning levels. Check loading, worker/WASM fallback, and interaction states
+   relevant to the changed route.
+
+For exported-site validation, run `pnpm start` and repeat the route/deep-link
+check below `/pmoke/`. Record only concise, redacted evidence with route,
+locale, viewport, theme, and whether it came from `next dev` or the export.
+Do not commit MCP screenshots, recordings, console dumps, personal paths, or
+raw data unless a reviewed visual snapshot is an explicit project contract.
+Prefer snapshots and narrowly scoped read-only evaluation; do not use
+`browser_run_code_unsafe` for routine checks. Playwright MCP complements, but
+does not replace, `pnpm check`, `pnpm test:e2e`, the Nix-provided browser, or
+the CI browser/accessibility/visual and Lighthouse gates. If MCP is unavailable,
+use the Nix-provided browser and the repository's Playwright CLI checks, and
+report the limitation.
+
 ## Product map
 
 - `website/app/`, `components/`, and `styles/`: Next.js routes and UI.
@@ -101,12 +132,13 @@ and Review 2 explicitly rather than fabricating a second approval.
    - `http://localhost:3000/pmoke/en/`
    - `http://localhost:3000/pmoke/ja/`
 
-   Use an attached browser or Playwright when available. Check at least a wide
-   desktop viewport, a tablet or narrow desktop viewport, and a phone viewport;
-   check light/dark mode, keyboard focus, reduced-motion behavior, loading and
-   error states, and the browser console for relevant errors. If no browser is
-   available, report the live URL and the limitation instead of claiming a
-   visual pass.
+   Use the Playwright MCP UI checkpoint above when it is available. Otherwise,
+   use an attached browser or the Nix-provided Playwright browser. Check at
+   least a wide desktop viewport, a tablet or narrow desktop viewport, and a
+   phone viewport; check light/dark mode, keyboard focus, reduced-motion
+   behavior, loading and error states, and the browser console for relevant
+   errors. If no browser is available, report the live URL and limitation
+   instead of claiming a visual pass.
 
 4. Stop at a visual checkpoint when layout, typography, interaction, or visual
    hierarchy is a matter of product choice. Show the route/viewport evidence

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,9 +254,17 @@ split:
   vulnerability-reporting instructions. A GitHub Project may provide an
   optional dashboard, but it is not a requirements or status source of truth.
 - Track one durable, user-facing goal in a GitHub Issue; open a normal linked
-  PR when implementation starts and keep its description as a short
+  PR when public implementation starts and keep its description as a short
   scope/outcome/validation/blocker checklist. Do not use a Draft PR phase.
-- When implementation starts, link the PR to the Issue with `Refs #N` and keep
+- Website UI slices that still require a product or visual decision use the
+  pre-publication visual sign-off gate below. Keep that slice on a private
+  local topic branch, start the Nix-managed local server, and review it with
+  the Playwright MCP checkpoint before the first commit or push. Obtain an
+  explicit user visual sign-off, then perform Review 1 and Review 2, create
+  the cohesive commit, push, and open the normal linked PR. This is a
+  temporary pre-publication checkpoint, not a Draft PR. The sign-off is a
+  product/visual decision, not browser or account authentication.
+- When public implementation starts, link the PR to the Issue with `Refs #N` and keep
   it open for review from the beginning. Record Review 1 on the Issue or design
   discussion and Review 2 on the complete staged PR diff, tests, and generated
   artifacts. Merge only after the acceptance criteria and validation evidence
@@ -277,9 +285,40 @@ split:
   PR with route, locale, viewport, theme, and dev/export context. Keep large or
   sensitive captures out of the repository unless versioned snapshots are an
   explicit project contract.
+- Do not wait for visual sign-off for security fixes, CI or release blockers,
+  non-visual correctness fixes, generated contract changes, or work where
+  delaying a public review would create a material risk. Use the ordinary
+  Issue and normal PR workflow for those changes. If a UI slice is not
+  approved, iterate locally and do not publish the unapproved design.
 - Report progress at meaningful milestones: scope, user-visible result,
   validation status, known environment limitation, and next decision. Keep
   public wording factual and safe to quote.
+
+### Website UI visual sign-off gate
+
+Use this gate for website changes whose layout, typography, animation, copy, or
+interaction is still a product choice:
+
+1. Make the durable goal and acceptance criteria explicit in the Issue, while
+   keeping the implementation on a private local topic branch.
+2. Enter the Nix development shell, run `pnpm run build:dev` from `website/`,
+   and review the changed route in the Playwright MCP browser checkpoint when
+   available. Otherwise use the Nix-provided browser/Playwright checks and
+   report the limitation. Check both locales and the relevant desktop, narrow,
+   and phone viewports, plus keyboard focus and console errors.
+3. Present concise route/viewport/theme evidence and ask for explicit user
+   visual sign-off. Do not treat a successful build or a browser login as
+   approval.
+4. If the direction is rejected, continue iterating locally. Once it is
+   approved, perform Review 1 and Review 2, commit the cohesive slice, push it,
+   and open the normal linked PR. Run the required checks and CI on that exact
+   head before merging.
+
+This gate is a temporary pre-publication checkpoint, not a Draft PR. It does
+not apply to security fixes, CI or release blockers, non-visual correctness
+fixes, generated contract changes, or work where delaying public review would
+create material risk; those changes follow the ordinary Issue and normal PR
+workflow.
 
 ## Long-running implementation and branch policy
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,12 @@ For agent-run local work, use Nix as the installation authority:
   missing package and keep the validation blocked rather than bypassing Nix.
 - Use Nix-provided browsers and native libraries for local validation. Record
   the package source/version and any environment limitation in the handoff.
+- When Playwright MCP is available in the agent session, use it for the
+  interactive website UI checkpoint after starting the site from the Nix
+  shell. Playwright MCP is a browser-control channel, not an installation
+  source; it does not replace the pinned Nix browser, project checks, or CI
+  browser gates. Keep MCP screenshots, console output, and recordings
+  untracked unless versioned visual evidence is explicitly required.
 - The repository shell provides Python 3.12 with the Nix-packaged NumPy, SciPy,
   lmfit, matplotlib, and pinned PyPI `gsplot` runtimes for the Rust/PyO3 and
   analysis tests; it sets `PYO3_PYTHON` to that interpreter and exposes its
@@ -439,6 +445,16 @@ route together before treating the change as complete:
 pnpm run build:dev
 # inspect http://localhost:3000/pmoke/en/ and /pmoke/ja/
 ```
+
+When Playwright MCP is available, use it for this checkpoint: navigate to both
+locale roots, capture an accessibility snapshot, resize through wide, narrow,
+and phone viewports, exercise keyboard focus and reduced-motion behavior, and
+inspect console errors. Use MCP screenshots only as concise, redacted evidence
+with route, locale, viewport, theme, and dev/export context. Prefer the
+Playwright MCP accessibility snapshot for locating controls; do not use an
+unsafe arbitrary-code browser runner for routine checks. If MCP is unavailable,
+use the Nix-provided browser with the repository's Playwright tests and report
+the environment limitation rather than claiming a visual pass.
 
 Check a changed route at wide, narrow, and phone widths, plus keyboard focus,
 light/dark mode, loading/error states, and the browser console. `build:dev`


### PR DESCRIPTION
Refs #161

## Outcome
Document the Playwright MCP UI checkpoint and require explicit user visual sign-off before the first commit or push for website UI/product-choice work.

## Changed surface
- `AGENTS.md`: public progress, Nix/MCP review, exceptions, and handoff sequence.
- `.agents/skills/pmoke-maintenance/SKILL.md`: repository-wide routing to the website sign-off gate.
- `.agents/skills/pmoke-website/SKILL.md`: MCP/fallback review, responsive/accessibility checks, sign-off, and normal PR handoff.

## Validation
- Review 1: requirements, scope, Draft PR policy, Nix boundary, fallback behavior, and public-data safety.
- Review 2: complete staged diff contains only the three guidance files.
- `git diff --check` passed.
- Skill frontmatter and guidance consistency checked.
- CI is pending on this exact head.

## Blockers
None known.

## Residual risk
This is documentation-only; browser/MCP availability remains an environment limitation and does not replace repository checks or CI.

## Next work
Wait for required CI checks, merge this exact head, close Issue #161, and delete the topic branch.
