### PR TITLE
fix(security): harden static export and CI downloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,10 @@ jobs:
 
       - name: Install linux-gpib userspace library
         run: |
+          archive_sha256="1b37b8c6bbe4844827f89e4986bc9c7b38e9dae8650f5bfa697d161afe09d898"
           curl -fL --retry 3 -o /tmp/linux-gpib.tar.gz \
             "https://sourceforge.net/projects/linux-gpib/files/linux-gpib%20for%203.x.x%20and%202.6.x%20kernels/4.3.6/linux-gpib-4.3.6.tar.gz/download"
+          echo "${archive_sha256}  /tmp/linux-gpib.tar.gz" | sha256sum --check
           tar -xzf /tmp/linux-gpib.tar.gz -C /tmp
           tar -xzf /tmp/linux-gpib-4.3.6/linux-gpib-user-4.3.6.tar.gz -C /tmp
           cd /tmp/linux-gpib-user-4.3.6
@@ -171,8 +173,10 @@ jobs:
 
       - name: Install linux-gpib userspace library
         run: |
+          archive_sha256="1b37b8c6bbe4844827f89e4986bc9c7b38e9dae8650f5bfa697d161afe09d898"
           curl -fL --retry 3 -o /tmp/linux-gpib.tar.gz \
             "https://sourceforge.net/projects/linux-gpib/files/linux-gpib%20for%203.x.x%20and%202.6.x%20kernels/4.3.6/linux-gpib-4.3.6.tar.gz/download"
+          echo "${archive_sha256}  /tmp/linux-gpib.tar.gz" | sha256sum --check
           tar -xzf /tmp/linux-gpib.tar.gz -C /tmp
           tar -xzf /tmp/linux-gpib-4.3.6/linux-gpib-user-4.3.6.tar.gz -C /tmp
           cd /tmp/linux-gpib-user-4.3.6

--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -83,7 +83,13 @@ jobs:
       - name: Enforce npm advisory and license policy
         working-directory: website
         run: |
-          pnpm audit
+          audit_exit=0
+          pnpm audit --json > "${RUNNER_TEMP}/pnpm-audit.json" || audit_exit=$?
+          node scripts/verify-audit.mjs "${RUNNER_TEMP}/pnpm-audit.json"
+          if [ "${audit_exit}" -gt 1 ]; then
+            exit "${audit_exit}"
+          fi
+          pnpm test:audit
           pnpm test:licenses
 
   build:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,12 +7,12 @@ private endpoints, raw captures, or exploit details in a public report.
 ## Supported versions
 
 Security fixes are developed on `main` and are backported at the maintainers'
-discretion. The latest non-draft release line is currently `v0.3.x`.
+discretion. The latest non-draft release line is currently `v0.4.x`.
 
 | Version | Security support |
 | --- | --- |
 | `main` | Supported; fixes land here first |
-| Latest non-draft release (`v0.3.x`) | Best-effort fixes when practical |
+| Latest non-draft release (`v0.4.x`) | Best-effort fixes when practical |
 | Older releases | No routine security backports |
 
 Update this table when a new non-draft release line becomes the supported

--- a/website/package.json
+++ b/website/package.json
@@ -22,11 +22,12 @@
     "test:export": "node --test scripts/verify-export-urls.test.mjs && node scripts/verify-export.mjs",
     "test:e2e": "playwright test",
     "test:lighthouse": "lhci collect --config=lighthouserc.cjs && node scripts/verify-lighthouse.mjs",
+    "test:audit": "node --test scripts/verify-audit.test.mjs",
     "test:licenses": "node --test scripts/release-metadata.test.mjs && node scripts/verify-licenses.mjs",
     "test:ai": "node scripts/verify-ai-resources.mjs",
     "test:search": "node scripts/evaluate-search.mjs",
     "test:signal": "node scripts/verify-signal.mjs",
-    "check": "npm run lint && npm run lint:ja && npm run lint:content && npm run lint:readme && npm run types:check && npm run test:search && npm run test:signal && npm run test:ai && npm run test:export"
+    "check": "npm run lint && npm run lint:ja && npm run lint:content && npm run lint:readme && npm run types:check && npm run test:search && npm run test:signal && npm run test:ai && npm run test:audit && npm run test:export"
   },
   "dependencies": {
     "@orama/orama": "3.1.18",

--- a/website/package.json
+++ b/website/package.json
@@ -19,7 +19,7 @@
     "lint:ja": "node scripts/lint-ja.mjs",
     "lint:content": "node scripts/verify-content.mjs",
     "lint:readme": "node scripts/verify-readme.mjs",
-    "test:export": "node scripts/verify-export.mjs",
+    "test:export": "node --test scripts/verify-export-urls.test.mjs && node scripts/verify-export.mjs",
     "test:e2e": "playwright test",
     "test:lighthouse": "lhci collect --config=lighthouserc.cjs && node scripts/verify-lighthouse.mjs",
     "test:licenses": "node --test scripts/release-metadata.test.mjs && node scripts/verify-licenses.mjs",

--- a/website/scripts/verify-audit.mjs
+++ b/website/scripts/verify-audit.mjs
@@ -1,0 +1,94 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ALLOWED_ADVISORY = Object.freeze({
+  // Temporary exact exception for the dev-only Lighthouse chain. Remove it
+  // when a verifiable patched extract-zip release is available.
+  github_advisory_id: 'GHSA-jmr9-qjv8-65gv',
+  module_name: 'extract-zip',
+  severity: 'high',
+  vulnerable_versions: '<=2.0.1',
+  patched_versions: '>=2.0.2',
+  finding: Object.freeze({
+    version: '2.0.1',
+    paths: Object.freeze([
+      '.>@lhci/cli>@lhci/utils>lighthouse>puppeteer-core>@puppeteer/browsers>extract-zip',
+      '.>@lhci/cli>lighthouse>puppeteer-core>@puppeteer/browsers>extract-zip',
+    ]),
+    dev: true,
+    optional: false,
+    bundled: false,
+  }),
+});
+
+function sorted(values) {
+  return [...values].sort();
+}
+
+function matchesAllowedAdvisory(advisory) {
+  if (
+    advisory.github_advisory_id !== ALLOWED_ADVISORY.github_advisory_id ||
+    advisory.module_name !== ALLOWED_ADVISORY.module_name ||
+    advisory.severity !== ALLOWED_ADVISORY.severity ||
+    advisory.vulnerable_versions !== ALLOWED_ADVISORY.vulnerable_versions ||
+    advisory.patched_versions !== ALLOWED_ADVISORY.patched_versions ||
+    advisory.findings?.length !== 1
+  ) {
+    return false;
+  }
+
+  const [finding] = advisory.findings;
+  return (
+    finding.version === ALLOWED_ADVISORY.finding.version &&
+    finding.dev === ALLOWED_ADVISORY.finding.dev &&
+    finding.optional === ALLOWED_ADVISORY.finding.optional &&
+    finding.bundled === ALLOWED_ADVISORY.finding.bundled &&
+    JSON.stringify(sorted(finding.paths)) === JSON.stringify(sorted(ALLOWED_ADVISORY.finding.paths))
+  );
+}
+
+export function evaluateAudit(audit) {
+  if (!audit || typeof audit !== 'object' || !audit.advisories || typeof audit.advisories !== 'object') {
+    throw new Error('pnpm audit JSON does not contain an advisories object');
+  }
+
+  const advisories = Object.values(audit.advisories);
+  const vulnerabilityCounts = audit.metadata?.vulnerabilities;
+  if (!vulnerabilityCounts || typeof vulnerabilityCounts !== 'object') {
+    throw new Error('pnpm audit JSON does not contain vulnerability counts');
+  }
+  const reportedAdvisoryCount = Object.values(vulnerabilityCounts).reduce(
+    (total, count) => total + (Number.isInteger(count) ? count : 0),
+    0,
+  );
+  if (reportedAdvisoryCount !== advisories.length) {
+    throw new Error(
+      `pnpm audit vulnerability count (${reportedAdvisoryCount}) does not match advisory records (${advisories.length})`,
+    );
+  }
+  return {
+    accepted: advisories.filter(matchesAllowedAdvisory),
+    unexpected: advisories.filter((advisory) => !matchesAllowedAdvisory(advisory)),
+  };
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const auditPath = process.argv[2];
+  if (!auditPath) throw new Error('Usage: node scripts/verify-audit.mjs <pnpm-audit.json>');
+
+  const audit = JSON.parse(await readFile(auditPath, 'utf8'));
+  const { accepted, unexpected } = evaluateAudit(audit);
+  for (const advisory of accepted) {
+    console.warn(
+      `Accepted unresolved development-only advisory ${advisory.github_advisory_id} for ${advisory.module_name}@${advisory.findings[0].version}; monitor upstream for a published fix.`,
+    );
+  }
+  if (unexpected.length > 0) {
+    throw new Error(
+      `Unexpected npm advisories: ${unexpected
+        .map((advisory) => `${advisory.github_advisory_id ?? advisory.id} (${advisory.module_name})`)
+        .join(', ')}`,
+    );
+  }
+}

--- a/website/scripts/verify-audit.test.mjs
+++ b/website/scripts/verify-audit.test.mjs
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { evaluateAudit } from './verify-audit.mjs';
+
+const knownAdvisory = {
+  github_advisory_id: 'GHSA-jmr9-qjv8-65gv',
+  module_name: 'extract-zip',
+  severity: 'high',
+  vulnerable_versions: '<=2.0.1',
+  patched_versions: '>=2.0.2',
+  findings: [
+    {
+      version: '2.0.1',
+      paths: [
+        '.>@lhci/cli>@lhci/utils>lighthouse>puppeteer-core>@puppeteer/browsers>extract-zip',
+        '.>@lhci/cli>lighthouse>puppeteer-core>@puppeteer/browsers>extract-zip',
+      ],
+      dev: true,
+      optional: false,
+      bundled: false,
+    },
+  ],
+};
+
+test('accepts only the documented unresolved development advisory', () => {
+  const result = evaluateAudit({
+    advisories: { known: knownAdvisory },
+    metadata: { vulnerabilities: { high: 1 } },
+  });
+  assert.equal(result.accepted.length, 1);
+  assert.equal(result.unexpected.length, 0);
+});
+
+test('accepts an audit with no advisories', () => {
+  const result = evaluateAudit({ advisories: {}, metadata: { vulnerabilities: {} } });
+  assert.deepEqual(result, { accepted: [], unexpected: [] });
+});
+
+test('rejects a new advisory', () => {
+  const result = evaluateAudit({
+    advisories: {
+      known: knownAdvisory,
+      unexpected: { ...knownAdvisory, github_advisory_id: 'GHSA-unexpected' },
+    },
+    metadata: { vulnerabilities: { high: 2 } },
+  });
+  assert.equal(result.accepted.length, 1);
+  assert.equal(result.unexpected.length, 1);
+});
+
+test('rejects a changed dependency path or version', () => {
+  const result = evaluateAudit({
+    advisories: {
+      changed: {
+        ...knownAdvisory,
+        findings: [{ ...knownAdvisory.findings[0], version: '2.0.2' }],
+      },
+    },
+    metadata: { vulnerabilities: { high: 1 } },
+  });
+  assert.equal(result.accepted.length, 0);
+  assert.equal(result.unexpected.length, 1);
+});
+
+test('rejects inconsistent audit counts', () => {
+  assert.throws(
+    () => evaluateAudit({ advisories: { known: knownAdvisory }, metadata: { vulnerabilities: { high: 0 } } }),
+    /does not match advisory records/,
+  );
+});

--- a/website/scripts/verify-export-urls.mjs
+++ b/website/scripts/verify-export-urls.mjs
@@ -1,0 +1,19 @@
+function extractDocumentUrls(document) {
+  const urls = [];
+  const attributePattern = /\b(?:href|content)=["']([^"']+)["']/gi;
+  const sitemapPattern = /<loc>([^<]+)<\/loc>/gi;
+  for (const match of document.matchAll(attributePattern)) urls.push(match[1].trim());
+  for (const match of document.matchAll(sitemapPattern)) urls.push(match[1].trim());
+  return urls;
+}
+
+export function hasExactUrl(document, expected) {
+  const expectedUrl = new URL(expected);
+  return extractDocumentUrls(document).some((candidate) => {
+    try {
+      return new URL(candidate).href === expectedUrl.href;
+    } catch {
+      return false;
+    }
+  });
+}

--- a/website/scripts/verify-export-urls.test.mjs
+++ b/website/scripts/verify-export-urls.test.mjs
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { hasExactUrl } from './verify-export-urls.mjs';
+
+const expected = 'https://kerr-group.github.io/pmoke/en/docs/quickstart/';
+
+test('accepts an exact HTML URL attribute', () => {
+  assert.equal(hasExactUrl(`<link rel="canonical" href="${expected}">`, expected), true);
+});
+
+test('accepts an exact sitemap URL', () => {
+  assert.equal(hasExactUrl(`<url>\n  <loc>${expected}</loc>\n</url>`, expected), true);
+});
+
+test('rejects a URL that only contains the expected URL in its path', () => {
+  const malicious = `https://evil.example.invalid/redirect?target=${encodeURIComponent(expected)}`;
+  assert.equal(hasExactUrl(`<meta content="${malicious}">`, expected), false);
+});
+
+test('rejects a lookalike host', () => {
+  const malicious = 'https://kerr-group.github.io.evil.example.invalid/pmoke/en/docs/quickstart/';
+  assert.equal(hasExactUrl(`<loc>${malicious}</loc>`, expected), false);
+});

--- a/website/scripts/verify-export.mjs
+++ b/website/scripts/verify-export.mjs
@@ -3,6 +3,8 @@ import { createHash } from 'node:crypto';
 import path from 'node:path';
 import { gzipSync } from 'node:zlib';
 
+import { hasExactUrl } from './verify-export-urls.mjs';
+
 const output = path.resolve('out');
 // Keep the raw budget tolerant of host-specific Rust/wasm-opt output while
 // retaining the compressed budget as the stricter transfer-size guard.
@@ -62,6 +64,7 @@ const EnglishCitation = await readFile(path.join(output, 'en/docs/citation/index
 const JapaneseCitation = await readFile(path.join(output, 'ja/docs/citation/index.html'), 'utf8');
 const sitemap = await readFile(path.join(output, 'sitemap.xml'), 'utf8');
 const robots = await readFile(path.join(output, 'robots.txt'), 'utf8');
+
 if (!English.includes('<html lang="en"')) throw new Error('English lang metadata is missing');
 if (!Japanese.includes('<html lang="ja"')) throw new Error('Japanese lang metadata is missing');
 if (!English.includes('Content-Security-Policy')) throw new Error('Static content security policy is missing');
@@ -91,14 +94,14 @@ if (!JapaneseAnalyzer.includes('波形アナライザー')) throw new Error('Jap
 if (!EnglishCitation.includes('Reproducible attribution')) throw new Error('English citation panel is missing');
 if (!JapaneseCitation.includes('再現可能な帰属情報')) throw new Error('Japanese citation panel is missing');
 if (!EnglishCitation.includes('10.1103/vy7j-ylb4')) throw new Error('Method DOI is missing from citation page');
-if (!JapaneseQuickstart.includes('https://kerr-group.github.io/pmoke/ja/docs/quickstart/')) {
+if (!hasExactUrl(JapaneseQuickstart, 'https://kerr-group.github.io/pmoke/ja/docs/quickstart/')) {
   throw new Error('Canonical project URL is missing');
 }
 if (!JapaneseQuickstart.includes('hrefLang="x-default"')) throw new Error('x-default metadata is missing');
-if (!JapaneseQuickstart.includes('https://kerr-group.github.io/pmoke/og.png')) {
+if (!hasExactUrl(JapaneseQuickstart, 'https://kerr-group.github.io/pmoke/og.png')) {
   throw new Error('Open Graph image is missing');
 }
-if (!sitemap.includes('https://kerr-group.github.io/pmoke/en/docs/quickstart/')) {
+if (!hasExactUrl(sitemap, 'https://kerr-group.github.io/pmoke/en/docs/quickstart/')) {
   throw new Error('Localized sitemap entry is missing');
 }
 if (!robots.includes('Sitemap: https://kerr-group.github.io/pmoke/sitemap.xml\n')) {


### PR DESCRIPTION
## Summary

- Replace static export URL substring assertions with exact parsed-URL checks and regression tests.
- Verify the pinned Linux GPIB archive SHA-256 before extraction in both CI install lanes.
- Align `SECURITY.md` with the current `v0.4.x` release line.
- The repository Actions default workflow token is read-only; write-capable jobs retain explicit job-level permissions.
- Keep npm audit strict while allowing only the exact, development-only `extract-zip@2.0.1` advisory record that is currently unavoidable upstream.

## Validation

- `nix develop -c bash -lc "cd website && pnpm check"`
- `nix develop -c bash -lc "cd website && pnpm test:licenses"`
- `nix develop -c bash -lc "cd website && node --test scripts/verify-export-urls.test.mjs && node scripts/verify-export.mjs"`
- `nix develop -c bash -lc "cd website && pnpm audit --json && node scripts/verify-audit.mjs ..."` (local audit returns the known advisory and the exact policy accepts it)
- `git diff --cached --check`

## Blocker / residual risk

- `pnpm audit` reports one high `extract-zip` advisory through Lighthouse/Puppeteer. The audit database requires `>=2.0.2`, but npm currently exposes `2.0.1` as latest and `2.0.2` is unavailable. CI does not dismiss the alert: it validates the complete advisory ID, package, version, development-only dependency paths, and audit counts, and fails for any other or changed advisory. Maintainers should monitor the upstream advisory and remove the exception when a published fix is available.

## Next work

- Re-run dependency and CodeQL scans on this exact PR head.
- Reassess the `extract-zip` alert when the upstream package chain publishes a verifiable fix.

Refs #163