### PR TITLE
fix(build): automatically discover macOS SDK library path for linker

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [alias]
 xtask = "run --package xtask --"
+
+[env]
+MACOSX_DEPLOYMENT_TARGET = { value = "14.0", force = false }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,25 @@
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=SDKROOT");
+    println!("cargo:rerun-if-env-changed=MACOSX_DEPLOYMENT_TARGET");
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    if target_os == "macos" {
+        configure_macos_link_search();
+    }
+}
+
+fn configure_macos_link_search() {
+    if let Ok(output) = Command::new("xcrun").args(["--show-sdk-path"]).output()
+        && output.status.success()
+        && let Ok(sdk_path) = String::from_utf8(output.stdout)
+    {
+        let sdk_path = sdk_path.trim();
+        if !sdk_path.is_empty() {
+            let sdk_usr_lib = std::path::Path::new(sdk_path).join("usr/lib");
+            if sdk_usr_lib.exists() {
+                println!("cargo:rustc-link-search=native={}", sdk_usr_lib.display());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Refs #170

## Summary
Adds a package build script (`build.rs`) for `pmoke` that automatically detects the macOS SDK library directory (via `xcrun --show-sdk-path`) and supplies `cargo:rustc-link-search=native=...` to the linker.

## Outcome
- `cargo build` and `cargo install` succeed out-of-the-box on macOS without requiring developers to manually pass `RUSTFLAGS="-L ..."` or environment variables.
- System libraries like `libiconv` linked by PyO3/Rust standard runtime are resolved automatically.
- Non-macOS builds are unaffected.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --locked -p pmoke --all-targets --no-default-features --features hw-core,hw-prologix-tcp,hw-prologix-serial -- -D warnings`
- `cargo build --locked --no-default-features --features hw-core,hw-prologix-tcp,hw-prologix-serial`
- `cargo install --path . --locked --no-default-features --features hw-core,hw-prologix-tcp,hw-prologix-serial`
- `cargo xtask docs-export`

## Blockers / Residual Risks
None.