### PR TITLE
fix: prevent reference FFT from selecting the DC component

### DIFF
--- a/src/lockin/reference/pytools/ref_analysis.py
+++ b/src/lockin/reference/pytools/ref_analysis.py
@@ -116,12 +116,43 @@ class ReferenceFFT:
         pass
 
     def fft(self, dt: float, y: NDArray, pad_factor: int = 3):
+        y = np.asarray(y, dtype=float)
+        if y.ndim != 1 or y.size < 2:
+            raise ValueError(
+                "reference FFT requires a one-dimensional signal with at least two samples"
+            )
+        if not np.isfinite(dt) or dt <= 0:
+            raise ValueError(f"reference FFT dt must be positive and finite (got {dt})")
+        if not np.all(np.isfinite(y)):
+            raise ValueError("reference FFT requires finite samples")
+
         fft = PreciseFFT(dt, y, pad_factor=pad_factor)
-        omega, fft_data = fft.get_data()
+        centered = y - np.mean(y)
+        signal_scale = float(np.max(np.abs(y)))
+        signal_range = float(np.ptp(y))
+        if not np.isfinite(signal_range) or signal_range <= np.finfo(float).eps * max(
+            signal_scale, np.finfo(float).tiny
+        ):
+            raise ValueError("reference signal has no non-DC component")
+        centered_scale = float(np.max(np.abs(centered)))
+        if not np.isfinite(centered_scale) or centered_scale == 0.0:
+            raise ValueError("reference signal has no non-DC component")
+
+        carrier_fft = PreciseFFT(dt, centered, pad_factor=pad_factor)
+        omega, fft_data = carrier_fft.get_data()
         freq = omega / (2 * np.pi)
 
-        idx = np.argmax(fft_data)
-        f_ref = float(abs(freq[idx]))
+        if len(fft_data) < 2:
+            raise ValueError("reference FFT has no non-DC frequency bins")
+        idx = 1 + int(np.argmax(fft_data[1:]))
+        peak_amplitude = float(fft_data[idx])
+        if not np.isfinite(peak_amplitude) or peak_amplitude <= (
+            np.finfo(float).eps * centered_scale
+        ):
+            raise ValueError("reference FFT has no resolvable non-DC carrier")
+        f_ref = float(freq[idx])
+        if not np.isfinite(f_ref) or f_ref <= 0.0:
+            raise ValueError(f"reference FFT estimated an invalid carrier frequency: {f_ref}")
 
         A_ref, theta_ref = fft.get_target_freq_component(2 * np.pi * f_ref)
         A_ref = float(A_ref)

--- a/src/lockin/reference/ref_analysis.rs
+++ b/src/lockin/reference/ref_analysis.rs
@@ -98,7 +98,7 @@ impl ReferenceFitter {
 
 #[cfg(test)]
 mod tests {
-    use super::ReferenceFFT;
+    use super::{RefFitParams, ReferenceFFT};
     use std::f64::consts::PI;
 
     #[test]
@@ -126,5 +126,54 @@ mod tests {
             "expected zero phase, got {}",
             result.omega_tref
         );
+    }
+
+    fn reference_with_offset(offset: f64) -> (f64, RefFitParams) {
+        let sample_rate = 100.0e6;
+        let sample_count = 4_096usize;
+        let frequency = 50.0 * sample_rate / sample_count as f64;
+        let amplitude = 0.5;
+        let dt = 1.0 / sample_rate;
+        let t: Vec<f64> = (0..sample_count).map(|index| index as f64 * dt).collect();
+        let y: Vec<f64> = t
+            .iter()
+            .map(|&time| offset + amplitude * (2.0 * PI * frequency * time).sin())
+            .collect();
+
+        (frequency, ReferenceFFT {}.fft(dt, &y).unwrap())
+    }
+
+    #[test]
+    fn reference_fft_ignores_positive_dc_offset() {
+        let (frequency, result) = reference_with_offset(0.30);
+
+        assert!((result.f_ref - frequency).abs() < 1.0e-6);
+        assert!((result.a_ref - 0.5).abs() < 1.0e-7);
+    }
+
+    #[test]
+    fn reference_fft_ignores_negative_dc_offset() {
+        let (frequency, result) = reference_with_offset(-0.30);
+
+        assert!((result.f_ref - frequency).abs() < 1.0e-6);
+        assert!((result.a_ref - 0.5).abs() < 1.0e-7);
+    }
+
+    #[test]
+    fn reference_fft_rejects_constant_input() {
+        let error = ReferenceFFT {}
+            .fft(1.0 / 100.0e6, &vec![0.30; 4_096])
+            .unwrap_err();
+
+        assert!(format!("{error:#}").contains("no non-DC component"));
+    }
+
+    #[test]
+    fn reference_fft_rejects_nonfinite_input() {
+        let mut input = vec![0.0; 4_096];
+        input[0] = f64::NAN;
+        let error = ReferenceFFT {}.fft(1.0 / 100.0e6, &input).unwrap_err();
+
+        assert!(format!("{error:#}").contains("requires finite samples"));
     }
 }


### PR DESCRIPTION
## Summary
- Remove the sampled mean from the carrier-search spectrum so DC offset and Hann-window leakage cannot win the FFT initializer.
- Preserve amplitude and phase extraction from the original signal.
- Reject non-finite, constant, and otherwise unresolvable reference inputs instead of returning a zero or fabricated carrier.
- Add deterministic positive/negative offset, zero-offset, constant-input, and non-finite-input regression coverage.

Refs #173

## Validation
- `nix develop -c cargo fmt --all -- --check`
- `nix develop -c cargo test --locked -p pmoke --all-targets --no-default-features` (403 unit tests + 4 CLI tests passed)
- `nix develop -c cargo clippy --locked -p pmoke --all-targets --no-default-features -- -D warnings`
- Focused reference FFT tests: 5 passed
- Embedded Python utility tests: 12 passed; scripts tests: 9 passed
- No live hardware access used

## Scope
- No change to configuration schema, lock-in filter behavior, phase convention, or Kerr extraction.
- No new external data flow.