### PR TITLE
fix: reject ambiguous legacy RAW channel metadata

### DIFF
--- a/src/utils/waveform.rs
+++ b/src/utils/waveform.rs
@@ -26,7 +26,7 @@ struct CsvColumns {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-#[serde(from = "RawWaveformMetadataRaw")]
+#[serde(try_from = "RawWaveformMetadataRaw")]
 struct RawWaveformMetadata {
     version: u32,
     status: Option<String>,
@@ -65,33 +65,71 @@ enum ChannelsFormat {
 }
 
 impl ChannelsFormat {
-    fn into_map(self) -> BTreeMap<String, RawChannelMetadata> {
+    fn into_map(self) -> Result<BTreeMap<String, RawChannelMetadata>, String> {
         match self {
-            ChannelsFormat::Map(map) => map,
+            ChannelsFormat::Map(map) => Ok(map),
             ChannelsFormat::List(list) => {
                 let mut map = BTreeMap::new();
                 for item in list {
-                    let ch = item.index.unwrap_or_else(|| {
-                        if let Some(pos) = item.file.find("ch") {
-                            let s = &item.file[pos + 2..];
-                            let digits: String =
-                                s.chars().take_while(|c| c.is_ascii_digit()).collect();
-                            digits.parse::<u8>().unwrap_or(1)
-                        } else {
-                            1
-                        }
-                    });
-                    map.insert(format!("ch{ch}"), item);
+                    let ch = match item.index {
+                        Some(ch) => ch,
+                        None => infer_legacy_channel(&item.file)?,
+                    };
+                    if ch == 0 {
+                        return Err(format!(
+                            "legacy RAW metadata channel index must be positive: {}",
+                            item.file
+                        ));
+                    }
+                    let key = format!("ch{ch}");
+                    if map.insert(key.clone(), item).is_some() {
+                        return Err(format!(
+                            "legacy RAW metadata contains duplicate channel mapping: {key}"
+                        ));
+                    }
                 }
-                map
+                Ok(map)
             }
         }
     }
 }
 
-impl From<RawWaveformMetadataRaw> for RawWaveformMetadata {
-    fn from(raw: RawWaveformMetadataRaw) -> Self {
-        Self {
+fn infer_legacy_channel(file: &str) -> Result<u8, String> {
+    let name = file
+        .rsplit(['/', '\\'])
+        .next()
+        .filter(|name| !name.is_empty())
+        .ok_or_else(|| {
+            format!("legacy RAW metadata cannot infer a channel from filename: {file}")
+        })?;
+    let digits = name
+        .strip_prefix("ch")
+        .map(|value| {
+            value
+                .chars()
+                .take_while(|ch| ch.is_ascii_digit())
+                .collect::<String>()
+        })
+        .filter(|digits| !digits.is_empty())
+        .ok_or_else(|| {
+            format!("legacy RAW metadata cannot infer a channel from filename: {file}")
+        })?;
+    let channel = digits
+        .parse::<u8>()
+        .map_err(|_| format!("legacy RAW metadata channel in filename is invalid: {file}"))?;
+    if channel == 0 {
+        return Err(format!(
+            "legacy RAW metadata channel in filename must be positive: {file}"
+        ));
+    }
+    Ok(channel)
+}
+
+impl TryFrom<RawWaveformMetadataRaw> for RawWaveformMetadata {
+    type Error = String;
+
+    fn try_from(raw: RawWaveformMetadataRaw) -> Result<Self, Self::Error> {
+        Ok(Self {
             version: raw.version,
             status: raw.status,
             pmoke_version: raw.pmoke_version,
@@ -101,8 +139,8 @@ impl From<RawWaveformMetadataRaw> for RawWaveformMetadata {
             resolved_config_file: raw.resolved_config_file,
             resolved_config_sha256: raw.resolved_config_sha256,
             oscilloscope: raw.oscilloscope,
-            channels: raw.channels.into_map(),
-        }
+            channels: raw.channels.into_map()?,
+        })
     }
 }
 

--- a/src/utils/waveform/tests.rs
+++ b/src/utils/waveform/tests.rs
@@ -2,6 +2,57 @@ use super::*;
 use crate::utils::checksum::sha256_hex;
 use std::path::PathBuf;
 
+fn legacy_channel_entry(file: &str, index: Option<u8>) -> String {
+    let index = index.map_or_else(String::new, |index| format!("index = {index}, "));
+    format!(
+        "{{ {index}file = \"{file}\", sample_count = 1, x_increment = 0.5, x_origin = 0.0, x_reference = 0.0, y_increment = 1.0, y_origin = 0.0, y_reference = 0.0 }}"
+    )
+}
+
+fn parse_legacy_metadata(entries: &[String]) -> Result<RawWaveformMetadata, toml::de::Error> {
+    let channels = entries.join(", ");
+    toml::from_str(&format!(
+        "version = 1\nchannels = [{channels}]\n\n[oscilloscope]\nwaveform_format = \"WORD\"\nbyte_order = \"little-endian\"\n"
+    ))
+}
+
+#[test]
+fn legacy_metadata_preserves_explicit_and_inferred_channel_order() {
+    let metadata = parse_legacy_metadata(&[
+        legacy_channel_entry("legacy.bin", Some(4)),
+        legacy_channel_entry("waveforms/ch2.u16le", None),
+    ])
+    .unwrap();
+
+    assert_eq!(
+        metadata
+            .channels
+            .keys()
+            .map(String::as_str)
+            .collect::<Vec<_>>(),
+        vec!["ch2", "ch4"]
+    );
+}
+
+#[test]
+fn legacy_metadata_rejects_unparseable_channel_filename() {
+    let error = parse_legacy_metadata(&[legacy_channel_entry("waveforms/unknown.u16le", None)])
+        .unwrap_err();
+
+    assert!(error.to_string().contains("cannot infer a channel"));
+}
+
+#[test]
+fn legacy_metadata_rejects_duplicate_channel_mapping() {
+    let error = parse_legacy_metadata(&[
+        legacy_channel_entry("ch1.u16le", None),
+        legacy_channel_entry("ch1-backup.u16le", None),
+    ])
+    .unwrap_err();
+
+    assert!(error.to_string().contains("duplicate channel mapping: ch1"));
+}
+
 #[test]
 fn raw_word_conversion_matches_dho_formula() {
     let bytes = [0x00, 0x00, 0x01, 0x00, 0x10, 0x00];


### PR DESCRIPTION
## Summary
- Make legacy list-style RAW channel metadata conversion fallible.
- Remove the implicit fallback to `ch1` when a filename cannot identify a channel.
- Reject zero channel indices and duplicate resolved channel mappings before insertion.
- Preserve explicit-index metadata and supported basename inference such as `ch2.u16le`.
- Add deterministic tests for valid ordering, unparseable filenames, and duplicate channels.

Refs #176

## Validation
- `nix develop -c cargo fmt --all -- --check`
- `nix develop -c cargo test --locked -p pmoke --all-targets --no-default-features` (411 unit tests + 4 CLI tests passed)
- `nix develop -c cargo clippy --locked -p pmoke --all-targets --no-default-features -- -D warnings`
- Legacy waveform metadata focused tests: 33 passed
- No live hardware access used

## Scope
- Modern map-style metadata remains unchanged.
- No RAW schema redesign, external I/O, or acquisition behavior changes.