### PR TITLE
chore(release): prepare v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,33 @@
 
 ## Unreleased
 
+## v0.4.1 — 2026-08-21
+
 ### Changes
 
 - The bilingual homepage now uses a compact, responsive four-stage pulsed-field
   MOKE workflow with stable transitions, aligned signal axes, and clearer
   numerical lock-in, phase-alignment, and Kerr-angle terminology.
+
+### Fixes
+
+- macOS builds now discover the active SDK library path automatically for the
+  linker.
+- Durable writes to bare relative destinations such as `config.toml` and
+  `out.csv` now synchronize the current directory correctly.
+- Reference-frequency initialization ignores DC offsets and rejects constant or
+  otherwise invalid reference inputs instead of producing a fabricated carrier.
+- Explicit CSV time axes are validated for finite, positive, and uniform
+  sampling before analysis uses a global interval.
+- CSV headers now use standards-compliant escaping, and preflight validation no
+  longer truncates an existing destination on failure.
+- Ambiguous legacy RAW channel metadata now fails closed instead of silently
+  falling back to or overwriting `ch1`.
+
+### Security and CI
+
+- Static export URL checks, CI downloads, and dependency-audit handling were
+  hardened without changing the user-facing analysis contract.
 
 ## v0.4.0 — 2026-08-12
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1270,7 +1270,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "pmoke"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmoke"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/website/content/docs/en/cli/reference.mdx
+++ b/website/content/docs/en/cli/reference.mdx
@@ -7,7 +7,7 @@ description: Generated command and option reference for the complete pmoke featu
 
 > Generated from typed clap metadata. Manual edits are overwritten.
 
-<ReferenceMetadata pmokeVersion="0.4.0" schemaVersion={5} />
+<ReferenceMetadata pmokeVersion="0.4.1" schemaVersion={5} />
 
 ## Command index
 

--- a/website/content/docs/en/configuration/reference.mdx
+++ b/website/content/docs/en/configuration/reference.mdx
@@ -7,7 +7,7 @@ description: Generated field reference for pmoke config schema version 5.
 
 > Generated from the typed config metadata registry. Manual edits are overwritten.
 
-<ReferenceMetadata pmokeVersion="0.4.0" schemaVersion={5} />
+<ReferenceMetadata pmokeVersion="0.4.1" schemaVersion={5} />
 
 [JSON Schema](https://kerr-group.github.io/pmoke/config.schema.json) · [`pmoke config explain`](../../cli/reference#pmoke-config-explain)
 

--- a/website/content/docs/ja/cli/reference.mdx
+++ b/website/content/docs/ja/cli/reference.mdx
@@ -7,7 +7,7 @@ description: pmokeの全featureを対象とする、commandとoptionの自動生
 
 > 型付きclap metadataから自動生成。手動編集は上書き対象。
 
-<ReferenceMetadata pmokeVersion="0.4.0" schemaVersion={5} />
+<ReferenceMetadata pmokeVersion="0.4.1" schemaVersion={5} />
 
 ## コマンド索引
 

--- a/website/content/docs/ja/configuration/reference.mdx
+++ b/website/content/docs/ja/configuration/reference.mdx
@@ -7,7 +7,7 @@ description: pmoke config schema version 5の自動生成fieldリファレンス
 
 > 型付きconfig metadata registryから自動生成。手動編集は上書き対象。
 
-<ReferenceMetadata pmokeVersion="0.4.0" schemaVersion={5} />
+<ReferenceMetadata pmokeVersion="0.4.1" schemaVersion={5} />
 
 [JSON Schema](https://kerr-group.github.io/pmoke/config.schema.json) · [`pmoke config explain`](../../cli/reference#pmoke-config-explain)
 

--- a/website/generated/cli-reference.json
+++ b/website/generated/cli-reference.json
@@ -1,6 +1,6 @@
 {
   "format_version": 1,
-  "pmoke_version": "0.4.0",
+  "pmoke_version": "0.4.1",
   "feature_set": "hw-core",
   "command": {
     "name": "pmoke",

--- a/website/generated/config-reference.json
+++ b/website/generated/config-reference.json
@@ -1,6 +1,6 @@
 {
   "format_version": 1,
-  "pmoke_version": "0.4.0",
+  "pmoke_version": "0.4.1",
   "schema_version": 5,
   "fields": [
     {

--- a/website/public/config.schema.json
+++ b/website/public/config.schema.json
@@ -2,7 +2,7 @@
   "$id": "https://kerr-group.github.io/pmoke/config.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
-  "description": "pmoke 0.4.0 configuration schema v5",
+  "description": "pmoke 0.4.1 configuration schema v5",
   "properties": {
     "data": {
       "additionalProperties": false,
@@ -1626,7 +1626,7 @@
       }
     ],
     "format_version": 1,
-    "pmoke_version": "0.4.0",
+    "pmoke_version": "0.4.1",
     "schema_version": 5,
     "semantic_constraints": [
       "channel assignments must be unique across sensors, reference, and lock-in signals",


### PR DESCRIPTION
## Summary
- Bump the pmoke CLI package from `0.4.0` to `0.4.1`.
- Finalize the `v0.4.1` changelog dated 2026-08-21 with the post-v0.4.0 fixes and security/CI hardening.
- Regenerate CLI/configuration references and schema metadata for `0.4.1`.

## Validation
- `nix develop -c cargo fmt --all -- --check`
- `nix develop -c cargo test --locked -p xtask` (3 passed)
- `nix develop -c cargo check --locked --workspace --all-targets --no-default-features`
- `nix develop -c cargo test --locked -p pmoke --all-targets --no-default-features` (411 unit tests + 4 CLI tests passed)
- `nix develop -c cargo clippy --locked -p pmoke --all-targets --no-default-features -- -D warnings`
- `nix develop -c pnpm check` (website source, generated-reference, audit, search, and export checks passed)
- `pmoke --version` → `pmoke 0.4.1`
- Generated docs export is idempotent

## Release handoff
- This PR prepares the repository for `v0.4.1`.
- Tag creation and GitHub Release publication are intentionally left to the maintainer.