### PR TITLE
fix(clippy): use array chunks for raw waveform words

### DIFF
--- a/crates/instruments/src/rigol/dho5108/dho5108.rs
+++ b/crates/instruments/src/rigol/dho5108/dho5108.rs
@@ -393,8 +393,8 @@ impl DHO5108 {
         let y_ref = raw.preamble.y_reference;
 
         let mut result = Vec::with_capacity(raw.data.len() / 2);
-        for chunk in raw.data.chunks_exact(2) {
-            let v = u16::from_le_bytes([chunk[0], chunk[1]]) as f64;
+        for &[low, high] in raw.data.as_chunks::<2>().0 {
+            let v = u16::from_le_bytes([low, high]) as f64;
             let y = (v - y_ori - y_ref) * y_inc;
             result.push(y);
         }

--- a/src/commands/completions.rs
+++ b/src/commands/completions.rs
@@ -160,8 +160,8 @@ fn decode_utf16(bytes: &[u8], little_endian: bool) -> Result<String> {
     if !bytes.len().is_multiple_of(2) {
         bail!("UTF-16 profile has an incomplete code unit");
     }
-    let units = bytes.chunks_exact(2).map(|chunk| {
-        let pair = [chunk[0], chunk[1]];
+    let units = bytes.as_chunks::<2>().0.iter().map(|&[low, high]| {
+        let pair = [low, high];
         if little_endian {
             u16::from_le_bytes(pair)
         } else {

--- a/src/commands/export/npy.rs
+++ b/src/commands/export/npy.rs
@@ -659,8 +659,10 @@ mod tests {
         assert!(header.contains("'shape': (2, 2)"));
         let payload = &bytes[10 + header_len..];
         let values = payload
-            .chunks_exact(8)
-            .map(|chunk| f64::from_le_bytes(chunk.try_into().unwrap()))
+            .as_chunks::<8>()
+            .0
+            .iter()
+            .map(|&chunk| f64::from_le_bytes(chunk))
             .collect::<Vec<_>>();
         assert_eq!(values, vec![1.0, 3.0, 2.0, 4.0]);
         fs::remove_file(path).unwrap();

--- a/src/commands/fetch.rs
+++ b/src/commands/fetch.rs
@@ -1328,9 +1328,11 @@ fn convert_raw_word_to_voltages(raw: &DhoRawWaveform) -> Vec<f64> {
     };
 
     raw.data
-        .chunks_exact(2)
-        .map(|chunk| {
-            let word = u16::from_le_bytes([chunk[0], chunk[1]]);
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .map(|&[low, high]| {
+            let word = u16::from_le_bytes([low, high]);
             scale.value_at(word)
         })
         .collect()

--- a/src/phase/mod.rs
+++ b/src/phase/mod.rs
@@ -165,7 +165,7 @@ pub fn phase_analysis(cfg: &Config, li_result: &[Vec<f64>]) -> Result<PhaseAnaly
         bail!("non_finite_phase: phase analysis columns must contain only finite values");
     }
 
-    let pairs: Vec<_> = li_result.chunks_exact(2).collect();
+    let pairs = li_result.as_chunks::<2>().0;
 
     let [
         [li1x, li1y],
@@ -175,7 +175,7 @@ pub fn phase_analysis(cfg: &Config, li_result: &[Vec<f64>]) -> Result<PhaseAnaly
         [li5x, li5y],
         [li6x, li6y],
         ..,
-    ] = pairs.as_slice()
+    ] = pairs
     else {
         unreachable!("lock-in column count was validated above");
     };


### PR DESCRIPTION
## Summary
- Replace constant-size `chunks_exact` loops with `as_chunks` across the DHO5108 raw-word path and pmoke byte-pair/array consumers.
- Preserve complete-pair decoding and existing handling of incomplete trailing bytes.
- Restore compatibility with the current Clippy lint set used by CI (Rust 1.98).

## Validation
- `nix develop -c cargo fmt --all -- --check`
- `nix develop -c cargo clippy --locked -p pmoke --all-targets --no-default-features -- -D warnings`
- `nix develop -c cargo clippy --locked -p instruments --all-targets --no-default-features --features gpib -- -D warnings`
- `nix develop -c cargo test --locked -p instruments --lib --no-default-features` (22 passed)
- No live instrument access used

## Scope
- No protocol, waveform conversion, public API, or release metadata changes.