### PR TITLE
chore(deps): update rust-cache action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Restore Rust cache
-        uses: Swatinem/rust-cache@a45951ff880207c249adf57334cf2e9bd81d6e1e # v2.9.1
+        uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2.9.1
         with:
           shared-key: workspace-all-features
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -129,7 +129,7 @@ jobs:
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 2026-08-02
 
       - name: Restore Rust cache
-        uses: Swatinem/rust-cache@a45951ff880207c249adf57334cf2e9bd81d6e1e # v2.9.1
+        uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2.9.1
         with:
           shared-key: performance-smoke
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -193,7 +193,7 @@ jobs:
           components: clippy
 
       - name: Restore Rust cache
-        uses: Swatinem/rust-cache@a45951ff880207c249adf57334cf2e9bd81d6e1e # v2.9.1
+        uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2.9.1
         with:
           shared-key: linux-full-hardware
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -249,7 +249,7 @@ jobs:
           components: clippy
 
       - name: Restore Rust cache
-        uses: Swatinem/rust-cache@a45951ff880207c249adf57334cf2e9bd81d6e1e # v2.9.1
+        uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2.9.1
         with:
           shared-key: windows-full
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -349,7 +349,7 @@ jobs:
           components: clippy
 
       - name: Restore Rust cache
-        uses: Swatinem/rust-cache@a45951ff880207c249adf57334cf2e9bd81d6e1e # v2.9.1
+        uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2.9.1
         with:
           shared-key: feature-suite-${{ matrix.os }}-${{ matrix.cache-key }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -428,7 +428,7 @@ jobs:
           components: clippy
 
       - name: Restore Rust cache
-        uses: Swatinem/rust-cache@a45951ff880207c249adf57334cf2e9bd81d6e1e # v2.9.1
+        uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2.9.1
         with:
           shared-key: analysis-${{ matrix.os }}-${{ matrix.python }}
           save-if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -113,7 +113,7 @@ jobs:
           tool: wasm-pack@0.15.0
 
       - name: Restore Rust cache
-        uses: Swatinem/rust-cache@a45951ff880207c249adf57334cf2e9bd81d6e1e # v2.9.1
+        uses: Swatinem/rust-cache@258712b0b7b1ddf8bddc9fc3b0faca682b2736c3 # v2.9.1
         with:
           shared-key: docs-wasm
           save-if: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
## Summary
- Update all six CI rust-cache pins and the documentation-site pin to commit `258712b0b7b1ddf8bddc9fc3b0faca682b2736c3`.
- This replacement PR is based on the current `main`; Dependabot PR #169 could not be rebased through the available GitHub OAuth scope because it modifies workflow files.

## Validation
- `git diff --check`
- Pin consistency reviewed across `.github/workflows/ci.yml` and `.github/workflows/docs-site.yml`
- Full CI and documentation-site checks will run on this current main head

## Scope
- GitHub Actions pin-only change; no Rust, website source, dependency lockfile, or release metadata changes.